### PR TITLE
feat: add `/status` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [BREAKING] Use `AccountTree` and update account witness proto definitions (#783).
 - Enabled running RPC component in `read-only` mode (#802).
 - [BREAKING] Update name of `ChainMmr` to `PartialBlockchain` (#807).
+- Added gRPC `/status` endpoint on all components (#817).
 
 ## v0.8.0 (2025-03-26)
 

--- a/bin/faucet/src/stub_rpc_api.rs
+++ b/bin/faucet/src/stub_rpc_api.rs
@@ -11,8 +11,8 @@ use miden_node_proto::generated::{
     responses::{
         CheckNullifiersByPrefixResponse, CheckNullifiersResponse, GetAccountDetailsResponse,
         GetAccountProofsResponse, GetAccountStateDeltaResponse, GetBlockByNumberResponse,
-        GetBlockHeaderByNumberResponse, GetNotesByIdResponse, SubmitProvenTransactionResponse,
-        SyncNoteResponse, SyncStateResponse,
+        GetBlockHeaderByNumberResponse, GetNotesByIdResponse, RpcStatusResponse,
+        SubmitProvenTransactionResponse, SyncNoteResponse, SyncStateResponse,
     },
     rpc::api_server,
 };
@@ -142,6 +142,10 @@ impl api_server::Api for StubRpcApi {
         &self,
         _request: Request<GetAccountProofsRequest>,
     ) -> Result<Response<GetAccountProofsResponse>, Status> {
+        unimplemented!()
+    }
+
+    async fn status(&self, _request: Request<()>) -> Result<Response<RpcStatusResponse>, Status> {
         unimplemented!()
     }
 }

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -2,8 +2,9 @@ use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
 use anyhow::{Context, Result};
 use miden_node_proto::generated::{
-    block_producer::api_server, requests::SubmitProvenTransactionRequest,
-    responses::SubmitProvenTransactionResponse,
+    block_producer::api_server,
+    requests::SubmitProvenTransactionRequest,
+    responses::{BlockProducerStatusResponse, SubmitProvenTransactionResponse},
 };
 use miden_node_utils::{
     formatting::{format_input_notes, format_output_notes},
@@ -194,6 +195,22 @@ impl api_server::Api for BlockProducerRpcServer {
             .map(tonic::Response::new)
             // This Status::from mapping takes care of hiding internal errors.
             .map_err(Into::into)
+    }
+
+    #[instrument(
+        target = COMPONENT,
+        name = "block_producer.server.status",
+        skip_all,
+        err
+    )]
+    async fn status(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<BlockProducerStatusResponse>, Status> {
+        Ok(tonic::Response::new(BlockProducerStatusResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            status: "connected".to_string(),
+        }))
     }
 }
 

--- a/crates/proto/src/generated/block_producer.rs
+++ b/crates/proto/src/generated/block_producer.rs
@@ -119,6 +119,30 @@ pub mod api_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// Returns the status info.
+        pub async fn status(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::BlockProducerStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/block_producer.Api/Status",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("block_producer.Api", "Status"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -142,6 +166,14 @@ pub mod api_server {
             >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::SubmitProvenTransactionResponse>,
+            tonic::Status,
+        >;
+        /// Returns the status info.
+        async fn status(
+            &self,
+            request: tonic::Request<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::BlockProducerStatusResponse>,
             tonic::Status,
         >;
     }
@@ -254,6 +286,45 @@ pub mod api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SubmitProvenTransactionSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/block_producer.Api/Status" => {
+                    #[allow(non_camel_case_types)]
+                    struct StatusSvc<T: Api>(pub Arc<T>);
+                    impl<T: Api> tonic::server::UnaryService<()> for StatusSvc<T> {
+                        type Response = super::super::responses::BlockProducerStatusResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::status(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = StatusSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/proto/src/generated/responses.rs
+++ b/crates/proto/src/generated/responses.rs
@@ -283,3 +283,39 @@ pub struct GetUnconsumedNetworkNotesResponse {
     #[prost(message, repeated, tag = "2")]
     pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
 }
+/// Represents the status of the node.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcStatusResponse {
+    /// The rpc component's running version.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// The store status.
+    #[prost(message, optional, tag = "3")]
+    pub store_status: ::core::option::Option<StoreStatusResponse>,
+    /// The block producer status.
+    #[prost(message, optional, tag = "4")]
+    pub block_producer_status: ::core::option::Option<BlockProducerStatusResponse>,
+}
+/// Represents the status of the store.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StoreStatusResponse {
+    /// The store's running version.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// The store's status.
+    #[prost(string, tag = "2")]
+    pub status: ::prost::alloc::string::String,
+    /// Number of the latest block in the chain.
+    #[prost(fixed32, tag = "3")]
+    pub chain_tip: u32,
+}
+/// Represents the status of the block producer.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockProducerStatusResponse {
+    /// The block producer's running version.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// The block producer's status.
+    #[prost(string, tag = "2")]
+    pub status: ::prost::alloc::string::String,
+}

--- a/crates/proto/src/generated/rpc.rs
+++ b/crates/proto/src/generated/rpc.rs
@@ -388,6 +388,28 @@ pub mod api_client {
             req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "SyncState"));
             self.inner.unary(req, path, codec).await
         }
+        /// Returns the status info of the node.
+        pub async fn status(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::RpcStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/rpc.Api/Status");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("rpc.Api", "Status"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -521,6 +543,14 @@ pub mod api_server {
             request: tonic::Request<super::super::requests::SyncStateRequest>,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::SyncStateResponse>,
+            tonic::Status,
+        >;
+        /// Returns the status info of the node.
+        async fn status(
+            &self,
+            request: tonic::Request<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::RpcStatusResponse>,
             tonic::Status,
         >;
     }
@@ -1115,6 +1145,45 @@ pub mod api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SyncStateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rpc.Api/Status" => {
+                    #[allow(non_camel_case_types)]
+                    struct StatusSvc<T: Api>(pub Arc<T>);
+                    impl<T: Api> tonic::server::UnaryService<()> for StatusSvc<T> {
+                        type Response = super::super::responses::RpcStatusResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::status(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = StatusSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/proto/src/generated/store.rs
+++ b/crates/proto/src/generated/store.rs
@@ -494,6 +494,28 @@ pub mod api_client {
                 .insert(GrpcMethod::new("store.Api", "GetUnconsumedNetworkNotes"));
             self.inner.unary(req, path, codec).await
         }
+        /// Returns the status info.
+        pub async fn status(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::StoreStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/store.Api/Status");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("store.Api", "Status"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -659,6 +681,14 @@ pub mod api_server {
             >,
         ) -> std::result::Result<
             tonic::Response<super::super::responses::GetUnconsumedNetworkNotesResponse>,
+            tonic::Status,
+        >;
+        /// Returns the status info.
+        async fn status(
+            &self,
+            request: tonic::Request<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::responses::StoreStatusResponse>,
             tonic::Status,
         >;
     }
@@ -1446,6 +1476,45 @@ pub mod api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetUnconsumedNetworkNotesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/store.Api/Status" => {
+                    #[allow(non_camel_case_types)]
+                    struct StatusSvc<T: Api>(pub Arc<T>);
+                    impl<T: Api> tonic::server::UnaryService<()> for StatusSvc<T> {
+                        type Response = super::super::responses::StoreStatusResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Api>::status(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = StatusSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -25,7 +25,8 @@ use miden_node_proto::{
             GetAccountStateDeltaResponse, GetBatchInputsResponse, GetBlockByNumberResponse,
             GetBlockHeaderByNumberResponse, GetBlockInputsResponse, GetNotesByIdResponse,
             GetTransactionInputsResponse, GetUnconsumedNetworkNotesResponse,
-            NullifierTransactionInputRecord, NullifierUpdate, SyncNoteResponse, SyncStateResponse,
+            NullifierTransactionInputRecord, NullifierUpdate, StoreStatusResponse,
+            SyncNoteResponse, SyncStateResponse,
         },
         store::api_server,
         transaction::TransactionSummary,
@@ -549,6 +550,21 @@ impl api_server::Api for StoreApi {
         Ok(Response::new(GetUnconsumedNetworkNotesResponse {
             notes: notes.into_iter().map(Into::into).collect(),
             next_token: next_page.token,
+        }))
+    }
+
+    #[instrument(
+        target = COMPONENT,
+        name = "store.server.status",
+        skip_all,
+        ret(level = "debug"),
+        err
+    )]
+    async fn status(&self, _request: Request<()>) -> Result<Response<StoreStatusResponse>, Status> {
+        Ok(Response::new(StoreStatusResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            status: "connected".to_string(),
+            chain_tip: self.state.latest_block_num().await.as_u32(),
         }))
     }
 }

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -28,6 +28,7 @@ pub fn rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
         Some("GetBlockByNumber") => rpc_span!("rpc.rpc", "GetBlockByNumber"),
         Some("GetAccountStateDelta") => rpc_span!("rpc.rpc", "GetAccountStateDelta"),
         Some("GetAccountProofs") => rpc_span!("rpc.rpc", "GetAccountProofs"),
+        Some("Status") => rpc_span!("rpc.rpc", "Status"),
         _ => rpc_span!("rpc.rpc", "Unknown"),
     };
     add_network_attributes(span, request)
@@ -40,10 +41,14 @@ pub fn rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
 /// Additionally also pulls in remote tracing context which allows the server trace to be connected
 /// to the client's origin trace.
 pub fn block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
-    let span = if let Some("SubmitProvenTransaction") = request.uri().path().rsplit('/').next() {
-        rpc_span!("block-producer.rpc", "SubmitProvenTransaction")
-    } else {
-        rpc_span!("block-producer.rpc", "Unknown")
+    let span = match request.uri().path().rsplit('/').next() {
+        Some("SubmitProvenTransaction") => {
+            rpc_span!("block-producer.rpc", "SubmitProvenTransaction")
+        },
+        Some("Status") => rpc_span!("block-producer.rpc", "Status"),
+        _ => {
+            rpc_span!("block-producer.rpc", "Unknown")
+        },
     };
 
     let span = add_otel_span_attributes(span, request);
@@ -72,6 +77,7 @@ pub fn store_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
         Some("GetTransactionInputs") => rpc_span!("store.rpc", "GetTransactionInputs"),
         Some("SyncNotes") => rpc_span!("store.rpc", "SyncNotes"),
         Some("SyncState") => rpc_span!("store.rpc", "SyncState"),
+        Some("Status") => rpc_span!("store.rpc", "Status"),
         _ => rpc_span!("store.rpc", "Unknown"),
     };
 

--- a/proto/proto/block_producer.proto
+++ b/proto/proto/block_producer.proto
@@ -4,9 +4,13 @@ package block_producer;
 
 import "requests.proto";
 import "responses.proto";
+import "google/protobuf/empty.proto";
 
 service Api {
     // Submits proven transaction to the Miden network
     rpc SubmitProvenTransaction(requests.SubmitProvenTransactionRequest) returns (responses.SubmitProvenTransactionResponse) {}
+
+    // Returns the status info.
+    rpc Status(google.protobuf.Empty) returns (responses.BlockProducerStatusResponse) {}
 }
 

--- a/proto/proto/responses.proto
+++ b/proto/proto/responses.proto
@@ -268,3 +268,36 @@ message GetUnconsumedNetworkNotesResponse {
     // The list of unconsumed network notes.
     repeated note.Note notes = 2;
 }
+
+// Represents the status of the node.
+message RpcStatusResponse {
+    // The rpc component's running version.
+    string version = 1;
+
+    // The store status.
+    StoreStatusResponse store_status = 3;
+
+    // The block producer status.
+    BlockProducerStatusResponse block_producer_status = 4;
+}
+
+// Represents the status of the store.
+message StoreStatusResponse {
+    // The store's running version.
+    string version = 1;
+
+    // The store's status.
+    string status = 2;
+
+    // Number of the latest block in the chain.
+    fixed32 chain_tip = 3;
+}
+
+// Represents the status of the block producer.
+message BlockProducerStatusResponse {
+    // The block producer's running version.
+    string version = 1;
+
+    // The block producer's status.
+    string status = 2;
+}

--- a/proto/proto/rpc.proto
+++ b/proto/proto/rpc.proto
@@ -4,6 +4,7 @@ package rpc;
 
 import "requests.proto";
 import "responses.proto";
+import "google/protobuf/empty.proto";
 
 service Api {
     // Returns a nullifier proof for each of the requested nullifiers.
@@ -64,4 +65,7 @@ service Api {
     // part of hashes. Thus, returned data contains excessive notes, client can make
     // additional filtering of that data on its side.
     rpc SyncState(requests.SyncStateRequest) returns (responses.SyncStateResponse) {}
+
+    // Returns the status info of the node.
+    rpc Status(google.protobuf.Empty) returns (responses.RpcStatusResponse) {}
 }

--- a/proto/proto/store.proto
+++ b/proto/proto/store.proto
@@ -6,6 +6,7 @@ package store;
 
 import "requests.proto";
 import "responses.proto";
+import "google/protobuf/empty.proto";
 
 service Api {
     // Applies changes of a new block to the DB and in-memory data structures.
@@ -78,4 +79,7 @@ service Api {
 
     // Returns the list of unconsumed network notes and the next page number to query.
     rpc GetUnconsumedNetworkNotes(requests.GetUnconsumedNetworkNotesRequest) returns (responses.GetUnconsumedNetworkNotesResponse) {}
+
+    // Returns the status info.
+    rpc Status(google.protobuf.Empty) returns (responses.StoreStatusResponse) {}
 }


### PR DESCRIPTION
Closes #794.

This PR adds a new `/status` endpoint on the store, block-producer and RPC components. The RPC endpoint hits the store and block-producer and aggregates their status into a single status response:

```
{
    "version": "0.9.0",
    "store_status": {
        "version": "0.9.0",
        "status": "connected",
        "chain_tip": 684
    },
    "block_producer_status": {
        "version": "0.9.0",
        "status": "connected"
    }
}
```

This endpoint can be easily accesed using Postman or grpcurl.

To run using grpcurl: 
```
grpcurl -import-path ./proto/proto -proto rpc.proto -plaintext localhost:57291 rpc.Api.Status
```