### PR TITLE
docs: update old GitHub and GitHub Pages URLs to new 0xMiden naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
 We want to make contributing to this project as easy and transparent as possible, whether it's:
 
-- Reporting a [bug](https://github.com/0xPolygonMiden/miden-node/issues/new?assignees=&labels=bug&projects=&template=1-bugreport.yml)
-- Taking part in [discussions](https://github.com/0xPolygonMiden/miden-node/discussions)
-- Submitting a [fix](https://github.com/0xPolygonMiden/miden-node/pulls)
-- Proposing new [features](https://github.com/0xPolygonMiden/miden-node/issues/new?assignees=&labels=enhancement&projects=&template=2-feature-request.yml)
+- Reporting a [bug](https://github.com/0xMiden/miden-node/issues/new?assignees=&labels=bug&projects=&template=1-bugreport.yml)
+- Taking part in [discussions](https://github.com/0xMiden/miden-node/discussions)
+- Submitting a [fix](https://github.com/0xMiden/miden-node/pulls)
+- Proposing new [features](https://github.com/0xMiden/miden-node/issues/new?assignees=&labels=enhancement&projects=&template=2-feature-request.yml)
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Miden node
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/miden-node/blob/main/LICENSE)
-[![test](https://github.com/0xPolygonMiden/miden-node/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-node/actions/workflows/test.yml)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-node/blob/main/LICENSE)
+[![test](https://github.com/0xMiden/miden-node/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/miden-node/actions/workflows/test.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.85+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-node)](https://crates.io/crates/miden-node)
 
@@ -20,16 +20,16 @@ Access to the network is provided via a gRPC interface which can be found [here]
 ## Documentation
 
 Documentation, tutorials and guides for the current Miden version (aka testnet) can be found
-[here](https://0xpolygonmiden.github.io/miden-docs/), including an operator manual and gRPC reference guide. This is
+[here](https://0xmiden.github.io/miden-docs/), including an operator manual and gRPC reference guide. This is
 your one-stop-shop for all things Miden.
 
 For node operators living on the development edge, we also host the latest unreleased documentation
-[here](https://0xpolygonmiden.github.io/miden-node/index.html).
+[here](https://0xmiden.github.io/miden-node/index.html).
 
 ## Contributing
 
 Developer documentation and onboarding guide is available
-[here](https://0xpolygonmiden.github.io/miden-node/developer/index.html).
+[here](https://0xmiden.github.io/miden-node/developer/index.html).
 
 At minimum, please see our [contributing](CONTRIBUTING.md) guidelines and our [makefile](Makefile) for example workflows
 e.g. run the testsuite using

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ Access to the network is provided via a gRPC interface which can be found [here]
 ## Documentation
 
 Documentation, tutorials and guides for the current Miden version (aka testnet) can be found
-[here](https://0xmiden.github.io/miden-docs/), including an operator manual and gRPC reference guide. This is
+[here](https://0xMiden.github.io/miden-docs/), including an operator manual and gRPC reference guide. This is
 your one-stop-shop for all things Miden.
 
 For node operators living on the development edge, we also host the latest unreleased documentation
-[here](https://0xmiden.github.io/miden-node/index.html).
+[here](https://0xMiden.github.io/miden-node/index.html).
 
 ## Contributing
 
 Developer documentation and onboarding guide is available
-[here](https://0xmiden.github.io/miden-node/developer/index.html).
+[here](https://0xMiden.github.io/miden-node/developer/index.html).
 
 At minimum, please see our [contributing](CONTRIBUTING.md) guidelines and our [makefile](Makefile) for example workflows
 e.g. run the testsuite using

--- a/docs/src/developer/codebase.md
+++ b/docs/src/developer/codebase.md
@@ -22,7 +22,7 @@ instead simply serve to enforce code organisation and decoupling.
 -------
 
 > [!NOTE]
-> [`miden-base`](https://github.com/0xPolygonMiden/miden-base) is an important dependency which
+> [`miden-base`](https://github.com/0xMiden/miden-base) is an important dependency which
 > contains the core Miden protocol definitions e.g. accounts, notes, transactions etc.
 
 ![workspace dependency tree](../resources/workspace_tree.svg)

--- a/docs/src/developer/index.md
+++ b/docs/src/developer/index.md
@@ -14,6 +14,6 @@ It is also a good idea to familiarise yourself with the [operator manual](../ope
 Living documents go stale - the code is the final arbitrator of truth.
 
 If you encounter any outdated, incorrect or misleading information, please
-[open an issue](https://github.com/0xPolygonMiden/miden-node/issues/new/choose).
+[open an issue](https://github.com/0xMiden/miden-node/issues/new/choose).
 
 </div>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,6 +16,6 @@ interface for users, dApps, wallets and other clients to submit transactions and
 ## Feedback
 
 Please report any issues, ask questions or leave feedback in the node repository
-[here](https://github.com/0xPolygonMiden/miden-node/issues/new/choose).
+[here](https://github.com/0xMiden/miden-node/issues/new/choose).
 
 This includes outdated, misleading, incorrect or just plain confusing information :)

--- a/docs/src/operator/index.md
+++ b/docs/src/operator/index.md
@@ -4,4 +4,4 @@ Welcome to the `Miden` node operator guide which should cover everything you nee
 Miden node.
 
 You can report any issues, ask questions or leave feedback at our project repo
-[here](https://github.com/0xPolygonMiden/miden-node/issues/new/choose).
+[here](https://github.com/0xMiden/miden-node/issues/new/choose).

--- a/docs/src/operator/installation.md
+++ b/docs/src/operator/installation.md
@@ -7,7 +7,7 @@ Alternatively, both also can be installed from source on most systems using the 
 
 ## Debian package
 
-Official Debian packages are available under our [releases](https://github.com/0xPolygonMiden/miden-node/releases) page.
+Official Debian packages are available under our [releases](https://github.com/0xMiden/miden-node/releases) page.
 Both `amd64` and `arm64` packages are available.
 
 Note that the packages include a `systemd` service which is disabled by default.
@@ -57,13 +57,13 @@ this for advanced use only. The incantation is a little different as you'll be t
 
 ```sh
 # Install from a specific branch
-cargo install --locked --git https://github.com/0xPolygonMiden/miden-node miden-node --branch <branch>
+cargo install --locked --git https://github.com/0xMiden/miden-node miden-node --branch <branch>
 
 # Install a specific tag
-cargo install --locked --git https://github.com/0xPolygonMiden/miden-node miden-node --tag <tag>
+cargo install --locked --git https://github.com/0xMiden/miden-node miden-node --tag <tag>
 
 # Install a specific git revision
-cargo install --locked --git https://github.com/0xPolygonMiden/miden-node miden-node --rev <git-sha>
+cargo install --locked --git https://github.com/0xMiden/miden-node miden-node --rev <git-sha>
 ```
 
 More information on the various `cargo install` options can be found

--- a/docs/src/user/rpc.md
+++ b/docs/src/user/rpc.md
@@ -4,7 +4,7 @@ This is a reference of the Node's public RPC interface. It consists of a gRPC AP
 transactions and query the state of the blockchain.
 
 The gRPC service definition can be found in the Miden node's `proto`
-[directory](https://github.com/0xPolygonMiden/miden-node/tree/main/proto) in the `rpc.proto` file.
+[directory](https://github.com/0xMiden/miden-node/tree/main/proto) in the `rpc.proto` file.
 
 <!--toc:start-->
 


### PR DESCRIPTION
## Describe your changes

This PR updates outdated URLs across all Markdown files to reflect the repository renaming from `0xPolygonMiden` to `0xMiden`.  
It also updates GitHub Pages links from `0xpolygonmiden.github.io` to `0xMiden.github.io`.