### PR TITLE
feat: add system monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1987,7 +1987,9 @@ dependencies = [
  "miden-objects",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
+ "sysinfo",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2387,6 +2389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,6 +2515,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3702,6 +3732,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b897c8ea620e181c7955369a31be5f48d9a9121cb59fd33ecef9ff2a34323422"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.1",
+]
+
+[[package]]
 name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,6 +4711,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,6 +4756,16 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -4741,6 +4817,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -28,7 +28,9 @@ miden-node-utils          = { workspace = true }
 miden-objects             = { workspace = true }
 rand                      = { workspace = true }
 rand_chacha               = { version = "0.9" }
+sysinfo                   = { version = "0.35" }
 tokio                     = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+tracing                   = { workspace = true }
 url                       = { workspace = true }
 
 [dev-dependencies]

--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -93,7 +93,7 @@ impl BlockProducerCommand {
             .context("Failed to extract socket address from block producer URL")?;
 
         // Start system monitor.
-        SystemMonitor::new(monitor_interval).run();
+        SystemMonitor::new(monitor_interval).run_with_supervisor();
 
         BlockProducer {
             block_producer_address,

--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -10,6 +10,7 @@ use super::{
     ENV_BLOCK_PRODUCER_URL, ENV_BLOCK_PROVER_URL, ENV_ENABLE_OTEL, ENV_STORE_URL,
     parse_duration_ms,
 };
+use crate::system_monitor::SystemMonitor;
 
 #[derive(clap::Subcommand)]
 pub enum BlockProducerCommand {
@@ -80,6 +81,9 @@ impl BlockProducerCommand {
         let block_producer_address = url
             .to_socket()
             .context("Failed to extract socket address from block producer URL")?;
+
+        // Start system monitor.
+        std::thread::spawn(move || SystemMonitor::new(None).run());
 
         BlockProducer {
             block_producer_address,

--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -93,7 +93,7 @@ impl BlockProducerCommand {
             .context("Failed to extract socket address from block producer URL")?;
 
         // Start system monitor.
-        std::thread::spawn(move || SystemMonitor::new(None, monitor_interval).run());
+        std::thread::spawn(move || SystemMonitor::new(monitor_interval).run());
 
         BlockProducer {
             block_producer_address,

--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -93,7 +93,7 @@ impl BlockProducerCommand {
             .context("Failed to extract socket address from block producer URL")?;
 
         // Start system monitor.
-        std::thread::spawn(move || SystemMonitor::new(monitor_interval).run());
+        SystemMonitor::new(monitor_interval).run();
 
         BlockProducer {
             block_producer_address,

--- a/bin/node/src/commands/bundled.rs
+++ b/bin/node/src/commands/bundled.rs
@@ -213,7 +213,9 @@ impl BundledCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        std::thread::spawn(move || SystemMonitor::new(Some(data_dir), monitor_interval).run());
+        std::thread::spawn(move || {
+            SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
+        });
 
         // Lookup table so we can identify the failed component.
         let component_ids = HashMap::from([

--- a/bin/node/src/commands/bundled.rs
+++ b/bin/node/src/commands/bundled.rs
@@ -213,9 +213,7 @@ impl BundledCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        std::thread::spawn(move || {
-            SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
-        });
+        SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
 
         // Lookup table so we can identify the failed component.
         let component_ids = HashMap::from([

--- a/bin/node/src/commands/bundled.rs
+++ b/bin/node/src/commands/bundled.rs
@@ -213,7 +213,10 @@ impl BundledCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
+
+        SystemMonitor::new(monitor_interval)
+            .with_store_metrics(data_dir)
+            .run_with_supervisor();
 
         // Lookup table so we can identify the failed component.
         let component_ids = HashMap::from([

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -15,6 +15,7 @@ const ENV_ENABLE_OTEL: &str = "MIDEN_NODE_ENABLE_OTEL";
 
 const DEFAULT_BLOCK_INTERVAL_MS: &str = "5000";
 const DEFAULT_BATCH_INTERVAL_MS: &str = "2000";
+const DEFAULT_MONITOR_INTERVAL_MS: &str = "10000";
 
 fn parse_duration_ms(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
     arg.parse().map(Duration::from_millis)

--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -73,7 +73,7 @@ impl RpcCommand {
             .context("Failed to bind to RPC's gRPC URL")?;
 
         // Start system monitor.
-        std::thread::spawn(move || SystemMonitor::new(None, monitor_interval).run());
+        std::thread::spawn(move || SystemMonitor::new(monitor_interval).run());
 
         Rpc { listener, store, block_producer }.serve().await.context("Serving RPC")
     }

--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -73,7 +73,7 @@ impl RpcCommand {
             .context("Failed to bind to RPC's gRPC URL")?;
 
         // Start system monitor.
-        SystemMonitor::new(monitor_interval).run();
+        SystemMonitor::new(monitor_interval).run_with_supervisor();
 
         Rpc { listener, store, block_producer }.serve().await.context("Serving RPC")
     }

--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -4,6 +4,7 @@ use miden_node_utils::grpc::UrlExt;
 use url::Url;
 
 use super::{ENV_BLOCK_PRODUCER_URL, ENV_ENABLE_OTEL, ENV_RPC_URL, ENV_STORE_URL};
+use crate::system_monitor::SystemMonitor;
 
 #[derive(clap::Subcommand)]
 pub enum RpcCommand {
@@ -55,6 +56,9 @@ impl RpcCommand {
         let listener = tokio::net::TcpListener::bind(listener)
             .await
             .context("Failed to bind to RPC's gRPC URL")?;
+
+        // Start system monitor.
+        std::thread::spawn(move || SystemMonitor::new(None).run());
 
         Rpc { listener, store, block_producer }.serve().await.context("Serving RPC")
     }

--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -73,7 +73,7 @@ impl RpcCommand {
             .context("Failed to bind to RPC's gRPC URL")?;
 
         // Start system monitor.
-        std::thread::spawn(move || SystemMonitor::new(monitor_interval).run());
+        SystemMonitor::new(monitor_interval).run();
 
         Rpc { listener, store, block_producer }.serve().await.context("Serving RPC")
     }

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -109,7 +109,9 @@ impl StoreCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        std::thread::spawn(move || SystemMonitor::new(Some(data_dir), monitor_interval).run());
+        std::thread::spawn(move || {
+            SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
+        });
 
         Store { listener, data_directory }
             .serve()

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -109,7 +109,9 @@ impl StoreCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
+        SystemMonitor::new(monitor_interval)
+            .with_store_metrics(data_dir)
+            .run_with_supervisor();
 
         Store { listener, data_directory }
             .serve()

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -2,7 +2,7 @@ use std::{
     fs::File,
     io::Write,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Context;
@@ -19,7 +19,10 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use url::Url;
 
-use super::{ENV_DATA_DIRECTORY, ENV_ENABLE_OTEL, ENV_STORE_URL};
+use super::{
+    DEFAULT_MONITOR_INTERVAL_MS, ENV_DATA_DIRECTORY, ENV_ENABLE_OTEL, ENV_STORE_URL,
+    parse_duration_ms,
+};
 use crate::system_monitor::SystemMonitor;
 
 #[derive(clap::Subcommand)]
@@ -55,6 +58,15 @@ pub enum StoreCommand {
         /// OpenTelemetry documentation. See our operator manual for further details.
         #[arg(long = "enable-otel", default_value_t = false, env = ENV_ENABLE_OTEL, value_name = "bool")]
         open_telemetry: bool,
+
+        /// Interval at which to monitor the system in milliseconds.
+        #[arg(
+            long = "monitor.interval",
+            default_value = DEFAULT_MONITOR_INTERVAL_MS,
+            value_parser = parse_duration_ms,
+            value_name = "MILLISECONDS"
+        )]
+        monitor_interval: Duration,
     },
 }
 
@@ -66,9 +78,12 @@ impl StoreCommand {
                 Self::bootstrap(&data_directory, &accounts_directory)
             },
             // Note: open-telemetry is handled in main.
-            StoreCommand::Start { url, data_directory, open_telemetry: _ } => {
-                Self::start(url, data_directory).await
-            },
+            StoreCommand::Start {
+                url,
+                data_directory,
+                open_telemetry: _,
+                monitor_interval,
+            } => Self::start(url, data_directory, monitor_interval).await,
         }
     }
 
@@ -80,7 +95,11 @@ impl StoreCommand {
         }
     }
 
-    async fn start(url: Url, data_directory: PathBuf) -> anyhow::Result<()> {
+    async fn start(
+        url: Url,
+        data_directory: PathBuf,
+        monitor_interval: Duration,
+    ) -> anyhow::Result<()> {
         let listener =
             url.to_socket().context("Failed to extract socket address from store URL")?;
         let listener = tokio::net::TcpListener::bind(listener)
@@ -90,7 +109,7 @@ impl StoreCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        std::thread::spawn(move || SystemMonitor::new(Some(data_dir)).run());
+        std::thread::spawn(move || SystemMonitor::new(Some(data_dir), monitor_interval).run());
 
         Store { listener, data_directory }
             .serve()

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -109,9 +109,7 @@ impl StoreCommand {
         // Start system monitor.
         let data_dir =
             DataDirectory::load(data_directory.clone()).context("failed to load data directory")?;
-        std::thread::spawn(move || {
-            SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
-        });
+        SystemMonitor::new(monitor_interval).with_store_metrics(data_dir).run();
 
         Store { listener, data_directory }
             .serve()

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -6,6 +6,7 @@ use clap::{Parser, Subcommand};
 use miden_node_utils::{logging::OpenTelemetry, version::LongVersion};
 
 mod commands;
+mod system_monitor;
 
 // COMMANDS
 // ================================================================================================

--- a/bin/node/src/system_monitor.rs
+++ b/bin/node/src/system_monitor.rs
@@ -120,9 +120,9 @@ impl SystemMonitor {
             process_disk_written,
             process_disk_read,
             // Store
-            db_file_size=store_metrics.db_file_size,
-            db_wal_size=store_metrics.db_wal_size,
-            block_storage_size=store_metrics.block_storage_size,
+            db_file_size=store_metrics.db_file,
+            db_wal_size=store_metrics.db_wal,
+            block_storage_size=store_metrics.block_storage,
         );
 
         Ok(())
@@ -134,32 +134,19 @@ impl SystemMonitor {
             return Ok(StoreMetrics::default());
         };
 
-        let db_file_size = std::fs::metadata(data_dir.database_path())?.len();
-        let db_wal_size =
+        let db_file = std::fs::metadata(data_dir.database_path())?.len();
+        let db_wal =
             std::fs::metadata(format!("{}-wal", data_dir.database_path().display()))?.len();
-        let block_storage_size = std::fs::metadata(data_dir.block_store_dir())?.len();
+        let block_storage = std::fs::metadata(data_dir.block_store_dir())?.len();
 
-        Ok(StoreMetrics {
-            db_file_size,
-            db_wal_size,
-            block_storage_size,
-        })
+        Ok(StoreMetrics { db_file, db_wal, block_storage })
     }
 }
 
 /// Metrics of the store.
+#[derive(Default)]
 struct StoreMetrics {
-    pub db_file_size: u64,
-    pub db_wal_size: u64,
-    pub block_storage_size: u64,
-}
-
-impl Default for StoreMetrics {
-    fn default() -> Self {
-        Self {
-            db_file_size: 0,
-            db_wal_size: 0,
-            block_storage_size: 0,
-        }
-    }
+    pub db_file: u64,
+    pub db_wal: u64,
+    pub block_storage: u64,
 }

--- a/bin/node/src/system_monitor.rs
+++ b/bin/node/src/system_monitor.rs
@@ -20,23 +20,25 @@ const MONITOR_INTERVAL: Duration = Duration::from_secs(10);
 pub struct SystemMonitor {
     sys: System,
     pid: Pid,
+    monitor_interval: Duration,
     data_directory: Option<DataDirectory>,
 }
 
 impl SystemMonitor {
     /// Creates a new system monitor.
-    pub fn new(data_directory: Option<DataDirectory>) -> Self {
+    pub fn new(data_directory: Option<DataDirectory>, monitor_interval: Duration) -> Self {
         Self {
             sys: System::new_all(),
             pid: Pid::from(std::process::id() as usize),
             data_directory,
+            monitor_interval,
         }
     }
 
     /// Runs the system monitor loop.
     pub fn run(&mut self) {
         loop {
-            std::thread::sleep(MONITOR_INTERVAL);
+            std::thread::sleep(self.monitor_interval);
             if let Err(err) = self.collect_system_metrics() {
                 error!(target: COMPONENT, ?err, "Error collecting system metrics");
             }

--- a/bin/node/src/system_monitor.rs
+++ b/bin/node/src/system_monitor.rs
@@ -48,6 +48,8 @@ impl SystemMonitor {
                 if let Err(err) = self.clone().run().await {
                     error!(target: COMPONENT, ?err, "Panicked while collecting system metrics. Restarting.");
                 }
+                // Wait an interval before restarting the monitor.
+                tokio::time::sleep(self.monitor_interval).await;
             }
         })
     }

--- a/bin/node/src/system_monitor.rs
+++ b/bin/node/src/system_monitor.rs
@@ -1,0 +1,116 @@
+use std::time::Duration;
+
+use miden_node_store::DataDirectory;
+use sysinfo::{Disk, Disks, Pid, System};
+use tracing::{error, info};
+
+const COMPONENT: &str = "system-monitor";
+const MONITOR_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Runs a system monitor loop that logs the system metrics every `MONITOR_INTERVAL` seconds.
+/// It is intended to be run in a separate thread.
+/// It logs the following information:
+/// - Memory usage
+/// - CPU usage
+/// - Disk usage
+/// - Process memory, CPU and disk usage
+/// - Database size
+/// - Database WAL size
+/// - Block storage size
+pub struct SystemMonitor {
+    sys: System,
+    pid: Pid,
+    data_directory: Option<DataDirectory>,
+}
+
+impl SystemMonitor {
+    /// Creates a new system monitor.
+    pub fn new(data_directory: Option<DataDirectory>) -> Self {
+        Self {
+            sys: System::new_all(),
+            pid: Pid::from(std::process::id() as usize),
+            data_directory,
+        }
+    }
+
+    /// Runs the system monitor loop.
+    pub fn run(&mut self) {
+        loop {
+            std::thread::sleep(MONITOR_INTERVAL);
+            if let Err(err) = self.collect_system_metrics() {
+                error!(target: COMPONENT, ?err, "Error collecting system metrics");
+            }
+        }
+    }
+
+    /// Collects the system metrics.
+    fn collect_system_metrics(&mut self) -> anyhow::Result<()> {
+        self.sys.refresh_all();
+
+        let disks = Disks::new_with_refreshed_list();
+        let system_disk_limit: u64 = disks.iter().map(Disk::total_space).sum();
+        let system_disk_state_available: u64 = disks.iter().map(Disk::available_space).sum();
+        let system_disk_used = system_disk_limit - system_disk_state_available;
+        #[allow(clippy::cast_precision_loss)]
+        let system_disk_utilization = (system_disk_used as f64 / system_disk_limit as f64) * 100.0;
+
+        let system_cpu_utilization = self.sys.global_cpu_usage() / 100.0;
+        let system_cpu_physical_count = System::physical_core_count();
+
+        let system_memory_usage = self.sys.used_memory();
+        let system_memory_limit = self.sys.total_memory();
+        let system_memory_available = self.sys.available_memory();
+        #[allow(clippy::cast_precision_loss)]
+        let system_memory_utilization = system_memory_usage as f64 / system_memory_limit as f64;
+
+        // SAFETY: the process exists since it is the current process.
+        let process = self.sys.process(self.pid).unwrap();
+        let process_memory_usage = process.memory();
+        let process_cpu_utilization = process.cpu_usage() / 100.0;
+        let process_disk_written = process.disk_usage().written_bytes;
+        let process_disk_read = process.disk_usage().read_bytes;
+
+        let (db_file_size, db_wal_size, block_storage_size) = self.collect_store_metrics()?;
+
+        info!(
+            target: COMPONENT,
+            // System memory
+            system_memory_limit,
+            system_memory_available,
+            system_memory_usage,
+            system_memory_utilization,
+            // System CPU
+            system_cpu_physical_count,
+            system_cpu_utilization,
+            // Disks
+            system_disk_limit,
+            system_disk_state_available,
+            system_disk_utilization,
+            // Process
+            process_memory_usage,
+            process_cpu_utilization,
+            process_disk_written,
+            process_disk_read,
+            // Node store data
+            db_file_size,
+            db_wal_size,
+            block_storage_size,
+        );
+
+        Ok(())
+    }
+
+    /// Collects the store metrics.
+    fn collect_store_metrics(&self) -> anyhow::Result<(u64, u64, u64)> {
+        if let Some(data_dir) = &self.data_directory {
+            let db_file_size = std::fs::metadata(data_dir.database_path())?.len();
+            let db_wal_size =
+                std::fs::metadata(format!("{}-wal", data_dir.database_path().display()))?.len();
+            let block_storage_size = std::fs::metadata(data_dir.block_store_dir())?.len();
+
+            Ok((db_file_size, db_wal_size, block_storage_size))
+        } else {
+            Ok((0, 0, 0))
+        }
+    }
+}

--- a/bin/node/src/system_monitor.rs
+++ b/bin/node/src/system_monitor.rs
@@ -7,7 +7,6 @@ use tracing::{error, info};
 const COMPONENT: &str = "system-monitor";
 
 /// Runs a system monitor loop that logs the system metrics every `MONITOR_INTERVAL` seconds.
-/// It is intended to be run in a separate thread.
 /// It logs the following information:
 /// - Memory usage
 /// - CPU usage
@@ -42,14 +41,16 @@ impl SystemMonitor {
         }
     }
 
-    /// Runs the system monitor loop.
-    pub fn run(&mut self) {
-        loop {
-            std::thread::sleep(self.monitor_interval);
-            if let Err(err) = self.log_system_metrics() {
-                error!(target: COMPONENT, ?err, "Error collecting system metrics");
+    /// Runs the system monitor loop on a separate thread.
+    pub fn run(mut self) {
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(self.monitor_interval);
+                if let Err(err) = self.log_system_metrics() {
+                    error!(target: COMPONENT, ?err, "Error collecting system metrics");
+                }
             }
-        }
+        });
     }
 
     /// Collects the system metrics and posts the structured log.

--- a/bin/node/src/system_monitor.rs
+++ b/bin/node/src/system_monitor.rs
@@ -81,14 +81,14 @@ impl SystemMonitor {
             system_memory_utilization,
             // System CPU
             system_cpu_physical_count,
-            system_cpu_utilization,
+            %system_cpu_utilization,
             // Disks
             system_disk_limit,
             system_disk_state_available,
-            system_disk_utilization,
+            %system_disk_utilization,
             // Process
             process_memory_usage,
-            process_cpu_utilization,
+            %process_cpu_utilization,
             process_disk_written,
             process_disk_read,
             // Node store data

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -99,6 +99,7 @@ impl Store {
 /// Represents the store's data-directory and its content paths.
 ///
 /// Used to keep our filepath assumptions in one location.
+#[derive(Clone)]
 pub struct DataDirectory(PathBuf);
 
 impl DataDirectory {


### PR DESCRIPTION
Addresses https://github.com/0xMiden/miden-node/issues/686.

This PR introduces a `SystemMonitor` struct as a module of the node binary. This struct runs a loop where it collects system metrics and posts those stats in a tracing event. To collect the system metrics, it uses [sysinfo](https://docs.rs/sysinfo/latest/sysinfo/). The monitor is run in a separate thread; it spawns when running the bundled node, or on the start command of each component independently.

If a block-producer or rpc component is started independently, the store stats will be not be shown.

### Metrics
(open to suggestions on more useful metrics to add)
```
info!(
    target: COMPONENT,
    // System memory
    system_memory_limit,
    system_memory_available,
    system_memory_usage,
    system_memory_utilization,
    // System CPU
    system_cpu_physical_count,
    system_cpu_utilization,
    // Disks
    system_disk_limit,
    system_disk_state_available,
    system_disk_utilization,
    // Process
    process_memory_usage,
    process_cpu_utilization,
    process_disk_written,
    process_disk_read,
    // Node store data
    db_file_size,
    db_wal_size,
    block_storage_size,
);
```

### Example output:
```
2025-05-07T18:56:40.237769Z  INFO system-monitor: bin/node/src/system_monitor.rs:75: system_memory_limit: 25769803776, system_memory_available: 9130770432, system_memory_usage: 14384185344, system_memory_utilization: 0.5581798553466797, system_cpu_physical_count: 14, system_cpu_utilization: 0.025455639, system_disk_limit: 1989325168640, system_disk_state_available: 1197322598932, system_disk_utilization: 39.8126250144139, process_memory_usage: 23003136, process_cpu_utilization: 0.0053307414, process_disk_written: 57344, process_disk_read: 0, db_file_size: 110592, db_wal_size: 3802792, block_storage_size: 96
```