### PR TITLE
feat: add PoW to faucet endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Faucet now supports the usage of a remote transaction prover (#830).
-- Added a required Proof-of-Work in the faucet to request tokens (#???).
+- Added a required Proof-of-Work in the faucet to request tokens (#831).
 
 ## v0.8.2 (2025-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Faucet now supports the usage of a remote transaction prover (#830).
+- Added a required Proof-of-Work in the faucet to request tokens (#???).
 
 ## v0.8.2 (2025-05-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,7 @@ dependencies = [
  "rand_chacha 0.9.0",
  "serde",
  "serde_json",
+ "sha3",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -31,8 +31,8 @@ miden-tx                     = { workspace = true, features = ["concurrent"] }
 rand                         = { workspace = true }
 rand_chacha                  = "0.9"
 serde                        = { version = "1.0", features = ["derive"] }
-sha3                         = { version = "0.10" }
 serde_json                   = { version = "1.0" }
+sha3                         = { version = "0.10" }
 thiserror                    = { workspace = true }
 tokio                        = { workspace = true, features = ["fs"] }
 tokio-stream                 = { workspace = true, features = ["net"] }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -31,6 +31,7 @@ miden-tx                     = { workspace = true, features = ["concurrent"] }
 rand                         = { workspace = true }
 rand_chacha                  = "0.9"
 serde                        = { version = "1.0", features = ["derive"] }
+sha3                         = { version = "0.10" }
 serde_json                   = { version = "1.0" }
 thiserror                    = { workspace = true }
 tokio                        = { workspace = true, features = ["fs"] }

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -34,13 +34,15 @@ pub struct FaucetConfig {
     /// Optional: Endpoint of the remote transaction prover in the format
     /// `<protocol>://<host>[:<port>]`
     pub remote_tx_prover_url: Option<Url>,
+    /// The salt to be used by the server to generate the `PoW` seed
+    pub pow_salt: String,
 }
 
 impl Display for FaucetConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
-            "{{ endpoint: \"{}\", node_url: \"{}\", timeout_ms: \"{}\", asset_amount_options: {:?}, faucet_account_path: \"{}\", remote_tx_prover_url: \"{:?}\" }}",
-            self.endpoint, self.node_url, self.timeout_ms, self.asset_amount_options, self.faucet_account_path.display(), self.remote_tx_prover_url
+            "{{ endpoint: \"{}\", node_url: \"{}\", timeout_ms: \"{}\", asset_amount_options: {:?}, faucet_account_path: \"{}\", remote_tx_prover_url: \"{:?}\", pow_salt: \"{}\" }}",
+            self.endpoint, self.node_url, self.timeout_ms, self.asset_amount_options, self.faucet_account_path.display(), self.remote_tx_prover_url, self.pow_salt
         ))
     }
 }
@@ -57,6 +59,7 @@ impl Default for FaucetConfig {
             asset_amount_options: AssetOptions::new(vec![100, 500, 1_000]).unwrap(),
             faucet_account_path: DEFAULT_FAUCET_ACCOUNT_PATH.into(),
             remote_tx_prover_url: None,
+            pow_salt: "miden-faucet".to_string(),
         }
     }
 }

--- a/bin/faucet/src/config.rs
+++ b/bin/faucet/src/config.rs
@@ -59,7 +59,7 @@ impl Default for FaucetConfig {
             asset_amount_options: AssetOptions::new(vec![100, 500, 1_000]).unwrap(),
             faucet_account_path: DEFAULT_FAUCET_ACCOUNT_PATH.into(),
             remote_tx_prover_url: None,
-            pow_salt: "miden-faucet".to_string(),
+            pow_salt: rand::random::<[u8; 32]>().into_iter().map(|b| b as char).collect(),
         }
     }
 }

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -110,8 +110,12 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
             // Maximum of 1000 requests in-queue at once. Overflow is rejected for faster feedback.
             let (tx_requests, rx_requests) = mpsc::channel(REQUESTS_QUEUE_SIZE);
 
-            let server =
-                Server::new(faucet.faucet_id(), config.asset_amount_options.clone(), tx_requests);
+            let server = Server::new(
+                faucet.faucet_id(),
+                config.asset_amount_options.clone(),
+                tx_requests,
+                config.pow_salt,
+            );
 
             // Capture in a variable to avoid moving into two branches
             let config_endpoint = config.endpoint;

--- a/bin/faucet/src/server/get_tokens.rs
+++ b/bin/faucet/src/server/get_tokens.rs
@@ -177,24 +177,24 @@ pub async fn get_tokens(
     // Response channel with buffer size 5 since there are currently 5 possible updates
     let (tx_result, rx_result) = mpsc::channel(5);
 
-    let mint_error = request
-        .validate(&state.asset_options, &server.pow_salt)
-        .map_err(GetTokenError::InvalidRequest)
-        .and_then(|request| {
-            let span = tracing::Span::current();
-            span.record("account", request.account_id.to_hex());
-            span.record("amount", request.asset_amount.inner());
-            span.record("note_type", request.note_type.to_string());
+    let mint_error =
+        request
+            .validate(&server.mint_state.asset_options, &server.pow_salt)
+            .map_err(GetTokenError::InvalidRequest)
+            .and_then(|request| {
+                let span = tracing::Span::current();
+                span.record("account", request.account_id.to_hex());
+                span.record("amount", request.asset_amount.inner());
+                span.record("note_type", request.note_type.to_string());
 
-            state
-                .request_sender
-                .try_send((request, tx_result.clone()))
-                .map_err(|err| match err {
-                    TrySendError::Full(_) => GetTokenError::FaucetOverloaded,
-                    TrySendError::Closed(_) => GetTokenError::FaucetClosed,
-                })
-        })
-        .err();
+                server.mint_state.request_sender.try_send((request, tx_result.clone())).map_err(
+                    |err| match err {
+                        TrySendError::Full(_) => GetTokenError::FaucetOverloaded,
+                        TrySendError::Closed(_) => GetTokenError::FaucetClosed,
+                    },
+                )
+            })
+            .err();
 
     if let Some(error) = mint_error {
         tx_result.send(Ok(error.into_event())).await.unwrap();

--- a/bin/faucet/src/server/get_tokens.rs
+++ b/bin/faucet/src/server/get_tokens.rs
@@ -164,7 +164,6 @@ impl RawMintRequest {
             &self.pow_seed,
             self.server_timestamp,
         ) {
-            error!("[get_tokens] invalid server signature");
             return Err(InvalidRequest::InvalidServerSignature);
         }
 

--- a/bin/faucet/src/server/mod.rs
+++ b/bin/faucet/src/server/mod.rs
@@ -36,6 +36,7 @@ use crate::{
 
 mod frontend;
 mod get_tokens;
+mod pow;
 
 // FAUCET STATE
 // ================================================================================================
@@ -113,6 +114,7 @@ impl Server {
                 .route("/background.png", get(frontend::get_background))
                 .route("/favicon.ico", get(frontend::get_favicon))
                 .route("/get_metadata", get(frontend::get_metadata))
+                .route("/pow", get(pow::get_pow_seed))
                 // TODO: This feels rather ugly, and would be nice to move but I can't figure out the types.
                 .route(
                     "/get_tokens",

--- a/bin/faucet/src/server/mod.rs
+++ b/bin/faucet/src/server/mod.rs
@@ -48,6 +48,7 @@ type RequestSender = mpsc::Sender<(MintRequest, mpsc::Sender<Result<Event, Infal
 pub struct Server {
     mint_state: GetTokensState,
     metadata: &'static Metadata,
+    pow_salt: String,
 }
 
 impl Server {
@@ -55,6 +56,7 @@ impl Server {
         faucet_id: FaucetId,
         asset_options: AssetOptions,
         request_sender: RequestSender,
+        pow_salt: String,
     ) -> Self {
         let mint_state = GetTokensState::new(request_sender, asset_options.clone());
         let metadata = Metadata {
@@ -64,7 +66,7 @@ impl Server {
         // SAFETY: Leaking is okay because we want it to live as long as the application.
         let metadata = Box::leak(Box::new(metadata));
 
-        Server { mint_state, metadata }
+        Server { mint_state, metadata, pow_salt }
     }
 
     pub async fn serve(self, url: Url) -> anyhow::Result<()> {

--- a/bin/faucet/src/server/pow.rs
+++ b/bin/faucet/src/server/pow.rs
@@ -90,7 +90,7 @@ pub(crate) fn check_pow_solution(seed: &str, solution: u64) -> bool {
     hasher.update(solution.to_string().as_bytes());
     let hash = &hasher.finalize().to_hex()[2..];
 
-    let leading_zeros = hash.chars().take(DIFFICULTY as usize).filter(|&c| c == '0').count();
+    let leading_zeros = hash.chars().take_while(|&c| c == '0').count();
     leading_zeros >= DIFFICULTY as usize
 }
 

--- a/bin/faucet/src/server/pow.rs
+++ b/bin/faucet/src/server/pow.rs
@@ -9,8 +9,7 @@ use sha3::{Digest, Sha3_256};
 const DIFFICULTY: u64 = 5;
 
 const SERVER_SALT: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("MIDEN_FAUCET_SERVER_SALT")
-        .expect("MIDEN_FAUCET_SERVER_SALT must be set")
+    std::env::var("MIDEN_FAUCET_SERVER_SALT").expect("MIDEN_FAUCET_SERVER_SALT must be set")
 });
 
 #[derive(Serialize)]

--- a/bin/faucet/src/server/pow.rs
+++ b/bin/faucet/src/server/pow.rs
@@ -1,4 +1,7 @@
-use std::sync::LazyLock;
+use std::{
+    sync::LazyLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use axum::{Json, response::IntoResponse};
 use miden_tx::utils::ToHex;
@@ -7,8 +10,9 @@ use serde::Serialize;
 use sha3::{Digest, Sha3_256};
 
 const DIFFICULTY: u64 = 5;
+const SERVER_TIMESTAMP_TOLERANCE_SECONDS: u64 = 30;
 
-const SERVER_SALT: LazyLock<String> = LazyLock::new(|| {
+static SERVER_SALT: LazyLock<String> = LazyLock::new(|| {
     std::env::var("MIDEN_FAUCET_SERVER_SALT").expect("MIDEN_FAUCET_SERVER_SALT must be set")
 });
 
@@ -17,6 +21,7 @@ struct PoWResponse {
     seed: String,
     difficulty: u64,
     server_signature: String,
+    timestamp: u64,
 }
 
 /// Generate a random hex string of specified length
@@ -29,54 +34,74 @@ fn random_hex_string(len: usize) -> String {
         .into_bytes();
 
     let hex_string = String::from_utf8(random_bytes).unwrap();
-    format!("0x{}", hex_string)
+    format!("0x{hex_string}")
 }
 
-/// Get a seed to be used by a client as the PoW seed.
+/// Get a seed to be used by a client as the `PoW` seed.
 ///
 /// The seed is a 64 character random hex string.
 pub(crate) async fn get_pow_seed() -> impl IntoResponse {
     // Generate a 64 character random hex string
     let random_seed = random_hex_string(64);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs();
     let mut hasher = Sha3_256::new();
     hasher.update(SERVER_SALT.as_bytes());
     hasher.update(&random_seed);
+    hasher.update(timestamp.to_string().as_bytes());
     let server_signature = hasher.finalize().to_hex();
 
     Json(PoWResponse {
         seed: random_seed,
         difficulty: DIFFICULTY,
         server_signature,
+        timestamp,
     })
 }
 
 /// Check the server signature.
 ///
 /// The server signature is the result of hashing the server salt and the seed.
-pub(crate) fn check_server_signature(server_signature: String, seed: String) -> bool {
+pub(crate) fn check_server_signature(server_signature: &str, seed: &str, timestamp: u64) -> bool {
     let mut hasher = Sha3_256::new();
     hasher.update(SERVER_SALT.as_bytes());
-    hasher.update(&seed);
+    hasher.update(seed);
+    hasher.update(timestamp.to_string().as_bytes());
     let hash = &hasher.finalize().to_hex();
 
-    hash == &server_signature
+    hash == server_signature
 }
 
-/// Check a PoW solution.
+/// Check a `PoW` solution.
 ///
-/// * `seed` - The seed to be used by the client as the PoW seed.
+/// * `seed` - The seed to be used by the client as the `PoW` seed.
 /// * `solution` - The solution to be checked.
 ///
 /// The solution is valid if the hash of the seed and the solution has at least `DIFFICULTY`
 /// leading zeros.
 ///
 /// Returns `true` if the solution is valid, `false` otherwise.
-pub(crate) fn check_pow_solution(seed: String, solution: u64) -> bool {
+pub(crate) fn check_pow_solution(seed: &str, solution: u64) -> bool {
     let mut hasher = Sha3_256::new();
-    hasher.update(&seed);
+    hasher.update(seed);
     hasher.update(solution.to_string().as_bytes());
     let hash = &hasher.finalize().to_hex()[2..];
 
     let leading_zeros = hash.chars().take(DIFFICULTY as usize).filter(|&c| c == '0').count();
     leading_zeros >= DIFFICULTY as usize
+}
+
+/// Check the received timestamp.
+///
+/// The timestamp is valid if it is within `SERVER_TIMESTAMP_TOLERANCE_SECONDS` seconds of the
+/// current time.
+pub(crate) fn check_server_timestamp(timestamp: u64) -> bool {
+    let server_timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs();
+
+    (server_timestamp - timestamp) <= SERVER_TIMESTAMP_TOLERANCE_SECONDS
 }

--- a/bin/faucet/src/server/pow.rs
+++ b/bin/faucet/src/server/pow.rs
@@ -1,0 +1,83 @@
+use std::sync::LazyLock;
+
+use axum::{Json, response::IntoResponse};
+use miden_tx::utils::ToHex;
+use rand::{Rng, rng};
+use serde::Serialize;
+use sha3::{Digest, Sha3_256};
+
+const DIFFICULTY: u64 = 5;
+
+const SERVER_SALT: LazyLock<String> = LazyLock::new(|| {
+    std::env::var("MIDEN_FAUCET_SERVER_SALT")
+        .expect("MIDEN_FAUCET_SERVER_SALT must be set")
+});
+
+#[derive(Serialize)]
+struct PoWResponse {
+    seed: String,
+    difficulty: u64,
+    server_signature: String,
+}
+
+/// Generate a random hex string of specified length
+fn random_hex_string(len: usize) -> String {
+    const HEX_CHARS: &[u8] = b"0123456789abcdef";
+    let mut rng = rng();
+    let random_bytes: Vec<u8> = (0..len)
+        .map(|_| HEX_CHARS[rng.random_range(0..HEX_CHARS.len())] as char)
+        .collect::<String>()
+        .into_bytes();
+
+    let hex_string = String::from_utf8(random_bytes).unwrap();
+    format!("0x{}", hex_string)
+}
+
+/// Get a seed to be used by a client as the PoW seed.
+///
+/// The seed is a 64 character random hex string.
+pub(crate) async fn get_pow_seed() -> impl IntoResponse {
+    // Generate a 64 character random hex string
+    let random_seed = random_hex_string(64);
+    let mut hasher = Sha3_256::new();
+    hasher.update(SERVER_SALT.as_bytes());
+    hasher.update(&random_seed);
+    let server_signature = hasher.finalize().to_hex();
+
+    Json(PoWResponse {
+        seed: random_seed,
+        difficulty: DIFFICULTY,
+        server_signature,
+    })
+}
+
+/// Check the server signature.
+///
+/// The server signature is the result of hashing the server salt and the seed.
+pub(crate) fn check_server_signature(server_signature: String, seed: String) -> bool {
+    let mut hasher = Sha3_256::new();
+    hasher.update(SERVER_SALT.as_bytes());
+    hasher.update(&seed);
+    let hash = &hasher.finalize().to_hex();
+
+    hash == &server_signature
+}
+
+/// Check a PoW solution.
+///
+/// * `seed` - The seed to be used by the client as the PoW seed.
+/// * `solution` - The solution to be checked.
+///
+/// The solution is valid if the hash of the seed and the solution has at least `DIFFICULTY`
+/// leading zeros.
+///
+/// Returns `true` if the solution is valid, `false` otherwise.
+pub(crate) fn check_pow_solution(seed: String, solution: u64) -> bool {
+    let mut hasher = Sha3_256::new();
+    hasher.update(&seed);
+    hasher.update(solution.to_string().as_bytes());
+    let hash = &hasher.finalize().to_hex()[2..];
+
+    let leading_zeros = hash.chars().take(DIFFICULTY as usize).filter(|&c| c == '0').count();
+    leading_zeros >= DIFFICULTY as usize
+}

--- a/bin/faucet/src/server/resources/index.html
+++ b/bin/faucet/src/server/resources/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Miden Faucet</title>
     <link rel="stylesheet" href="./index.css">
+    <!-- Load SHA3 library directly -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-sha3/0.8.0/sha3.min.js"></script>
+    <!-- Load our JavaScript after SHA3 library -->
+    <script src="./index.js"></script>
 </head>
 
 <body>
@@ -39,7 +43,6 @@
             miden consume-notes --account <span id="command-account-id"></span> <span id="note-id"></span>
         </p>
     </div>
-    <script src="./index.js"></script>
 </body>
 
 </html>

--- a/bin/faucet/src/server/resources/index.html
+++ b/bin/faucet/src/server/resources/index.html
@@ -7,7 +7,7 @@
     <title>Miden Faucet</title>
     <link rel="stylesheet" href="./index.css">
     <!-- Load SHA3 library directly -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-sha3/0.8.0/sha3.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-sha3/0.8.0/sha3.min.js" integrity="sha384-NKbaJKqJPrFeb86qfU2iNy4KO3oyIe6F5xm1PBYMpAkiVTxHjjafUKlebp0mAeNC" crossorigin="anonymous"></script>
     <!-- Load our JavaScript after SHA3 library -->
     <script src="./index.js"></script>
 </head>

--- a/bin/faucet/src/server/resources/index.js
+++ b/bin/faucet/src/server/resources/index.js
@@ -102,9 +102,12 @@ document.addEventListener('DOMContentLoaded', function () {
             method: "GET"
         });
 
+        status.textContent = "Received Proof of Work challenge";
+
         const powData = await powResponse.json();
 
         // Search for a nonce that satisfies the proof of work
+        status.textContent = "Resolving Proof of Work...";
         const nonce = await findValidNonce(powData.seed, powData.difficulty);
 
         const evtSource = new EventSource(window.location.href + 'get_tokens?' + new URLSearchParams({

--- a/bin/faucet/src/server/resources/index.js
+++ b/bin/faucet/src/server/resources/index.js
@@ -13,6 +13,15 @@ document.addEventListener('DOMContentLoaded', function () {
     const status = document.getElementById("loading-status");
     const txLink = document.getElementById('tx-link');
 
+    // Check if SHA3 is available right from the start
+    if (typeof sha3_256 === 'undefined') {
+        console.error("SHA3 library not loaded initially");
+        errorMessage.textContent = 'Cryptographic library not loaded. Please refresh the page.';
+        errorMessage.style.display = 'block';
+    } else {
+        console.log("SHA3 library is available at page load");
+    }
+
     fetchMetadata();
 
     privateButton.addEventListener('click', () => { handleButtonClick(true) });
@@ -80,8 +89,26 @@ document.addEventListener('DOMContentLoaded', function () {
 
         setLoadingState(true);
 
+        // Check if SHA3 library is loaded
+        if (typeof sha3_256 === 'undefined') {
+            console.error("SHA3 UNDEFINED when trying to handle button click");
+            errorMessage.textContent = "Cryptographic library not loaded. Please refresh the page and try again.";
+            errorMessage.style.display = 'block';
+            return;
+        }
+
+        // Get the pow seed, difficulty, and server signature
+        const powResponse = await fetch(window.location.href + 'pow', {
+            method: "GET"
+        });
+
+        const powData = await powResponse.json();
+
+        // Search for a nonce that satisfies the proof of work
+        const nonce = await findValidNonce(powData.seed, powData.difficulty);
+
         const evtSource = new EventSource(window.location.href + 'get_tokens?' + new URLSearchParams({
-            account_id: accountId, is_private_note: isPrivateNote, asset_amount: parseInt(assetSelect.value)
+            account_id: accountId, is_private_note: isPrivateNote, asset_amount: parseInt(assetSelect.value), pow_seed: powData.seed, pow_solution: nonce, server_signature: powData.server_signature
         }));
 
         evtSource.onopen = function () {
@@ -133,6 +160,52 @@ document.addEventListener('DOMContentLoaded', function () {
             txLink.href = data.explorer_url + '/tx/' + data.transaction_id;
             txLink.textContent = data.transaction_id;
         });
+    }
+
+    // Function to find a valid nonce for proof of work
+    async function findValidNonce(seed, difficulty) {
+        // Check again if SHA3 is available
+        if (typeof sha3_256 === 'undefined') {
+            console.error("SHA3 library not properly loaded. SHA3 object:", sha3_256);
+            throw new Error('SHA3 library not properly loaded. Please refresh the page.');
+        }
+
+        // Parse difficulty (number of required trailing zeros)
+        const requiredZeros = parseInt(difficulty);
+        const requiredPattern = '0'.repeat(requiredZeros);
+
+        let nonce = 0;
+        let validNonceFound = false;
+
+        while (!validNonceFound) {
+            // Generate a random nonce
+            nonce = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+
+            try {
+                // Compute hash using SHA3
+                let hash = sha3_256.create();
+                hash.update(seed);
+                hash.update(nonce.toString());
+                // Trim leading 0x
+                let digest = hash.hex().toString().slice(2);
+
+
+                // Check if the hash starts with the required number of zeros
+                if (digest.startsWith(requiredPattern)) {
+                    console.log("Found valid nonce! Nonce:", nonce, "Hash:", digest);
+                    validNonceFound = true;
+                    return nonce;
+                }
+            } catch (error) {
+                console.error('Error computing hash:', error);
+                throw new Error('Failed to compute hash: ' + error.message);
+            }
+
+            // Yield to browser to prevent freezing
+            if (nonce % 1000 === 0) {
+                await new Promise(resolve => setTimeout(resolve, 0));
+            }
+        }
     }
 
     function downloadBlob(blob, filename) {

--- a/bin/faucet/src/server/resources/index.js
+++ b/bin/faucet/src/server/resources/index.js
@@ -187,8 +187,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 hash.update(seed);
                 hash.update(nonce.toString());
                 // Trim leading 0x
-                let digest = hash.hex().toString().slice(2);
-
+                let digest = hash.hex().toString();
 
                 // Check if the hash starts with the required number of zeros
                 if (digest.startsWith(requiredPattern)) {

--- a/bin/faucet/src/server/resources/index.js
+++ b/bin/faucet/src/server/resources/index.js
@@ -108,7 +108,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const nonce = await findValidNonce(powData.seed, powData.difficulty);
 
         const evtSource = new EventSource(window.location.href + 'get_tokens?' + new URLSearchParams({
-            account_id: accountId, is_private_note: isPrivateNote, asset_amount: parseInt(assetSelect.value), pow_seed: powData.seed, pow_solution: nonce, server_signature: powData.server_signature
+            account_id: accountId, is_private_note: isPrivateNote, asset_amount: parseInt(assetSelect.value), pow_seed: powData.seed, pow_solution: nonce, server_signature: powData.server_signature, server_timestamp: powData.timestamp
         }));
 
         evtSource.onopen = function () {


### PR DESCRIPTION
Part of #821 

This PR adds a Proof-of-Work mechanism that ensures that the client spends at least ~2 seconds before being able to mint tokens.

It uses sha3-256 as hashing function and works by:

1. Before requesting token, the client sends a request to `/pow` and gets a random seed, a difficulty and a server signature.
 - The seed is a random generated hex string with 64 digits.
 - The difficulty is a number that represents the amount of leading zeros that the client needs to look for.
 - The current timestamp of the server.
 - The server signature is the hash of a secret server salt + the random seed + the timestamp.
2. The client uses the random seed to get a nonce such that the resultant digest has at least `difficulty` leading zeroes.
3. The server, in the `/get_tokens` endpoint, receives the random seed, the server signature, the server timestamp and the nonce use to obtain the resultant digest.
4. The server checks that the timestamp in a given range of time.
5. The server checks that the server signature is valid, by re-hashing the server salt + the just received seed + the timestamp, to ensure that the received seed was sent by the server.
6. The server checks that the received seed + the nonce does in fact has the necessary leading zeroes.