### PR TITLE
Add instrumentation to faucet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Enabled running RPC component in `read-only` mode (#802).
 - [BREAKING] Update name of `ChainMmr` to `PartialBlockchain` (#807).
 - Added gRPC `/status` endpoint on all components (#817).
+- Added `--enable-otel` and `MIDEN_FAUCET_ENABLE_OTEL` flag to faucet (#834).
 
 ## v0.8.0 (2025-03-26)
 
@@ -45,7 +46,7 @@
 - [BREAKING] Update `GetBlockInputs` RPC (#709).
 - [BREAKING] Added `batch_prover_url` to block producer configuration (#701).
 - [BREAKING] Added `block_prover_url` to block producer configuration (#719).
-- [BREAKING] Removed `miden-rpc-proto` and introduced `miden-node-proto-build` (#723). 
+- [BREAKING] Removed `miden-rpc-proto` and introduced `miden-node-proto-build` (#723).
 - [BREAKING] Updated to Rust Edition 2024 (#727).
 - [BREAKING] MSRV bumped to 1.85 (#727).
 - [BREAKING] Replaced `toml` configuration with CLI (#732).

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 anyhow           = { workspace = true }
 axum             = { version = "0.8", features = ["tokio"] }
-clap             = { version = "4.5", features = ["derive", "string"] }
+clap             = { version = "4.5", features = ["derive", "env", "string"] }
 http             = { workspace = true }
 http-body-util   = "0.1"
 miden-lib        = { workspace = true }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -31,7 +31,7 @@ use miden_tx::{
 };
 use rand::{random, rngs::StdRng};
 use tonic::transport::Channel;
-use tracing::info;
+use tracing::{info, instrument};
 
 use crate::{COMPONENT, config::FaucetConfig, errors::ClientError, store::FaucetDataStore};
 
@@ -121,6 +121,7 @@ impl FaucetClient {
     /// Executes a mint transaction for the target account.
     ///
     /// Returns the executed transaction and the expected output note.
+    #[instrument(target = COMPONENT, name = "faucet.client.execute_mint_transaction", skip_all, err)]
     pub fn execute_mint_transaction(
         &mut self,
         target_account_id: AccountId,
@@ -164,6 +165,7 @@ impl FaucetClient {
     }
 
     /// Proves and submits the executed transaction to the node.
+    #[instrument(target = COMPONENT, name = "faucet.client.prove_and_submit_transaction", skip_all, err)]
     pub async fn prove_and_submit_transaction(
         &mut self,
         executed_tx: ExecutedTransaction,

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -15,6 +15,7 @@ use miden_objects::{
 use serde::{Deserialize, Serialize};
 use tonic::body;
 use tracing::info;
+use tracing::{Instrument, Span, instrument};
 
 use crate::{COMPONENT, errors::HandlerError, state::FaucetState};
 
@@ -42,6 +43,7 @@ pub async fn get_metadata(
     (StatusCode::OK, Json(response))
 }
 
+#[instrument(parent = None, target = COMPONENT, name = "faucet.server.get_tokens", skip_all, err)]
 pub async fn get_tokens(
     State(state): State<FaucetState>,
     Json(req): Json<FaucetRequest>,

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -14,8 +14,7 @@ use miden_objects::{
 };
 use serde::{Deserialize, Serialize};
 use tonic::body;
-use tracing::info;
-use tracing::instrument;
+use tracing::{info, instrument};
 
 use crate::{COMPONENT, errors::HandlerError, state::FaucetState};
 
@@ -32,6 +31,7 @@ pub struct FaucetMetadataReponse {
     asset_amount_options: Vec<u64>,
 }
 
+#[instrument(parent = None, target = COMPONENT, name = "faucet.server.get_metadata", skip_all)]
 pub async fn get_metadata(
     State(state): State<FaucetState>,
 ) -> (StatusCode, Json<FaucetMetadataReponse>) {

--- a/bin/faucet/src/handlers.rs
+++ b/bin/faucet/src/handlers.rs
@@ -71,7 +71,6 @@ pub async fn get_tokens(
         .map_err(HandlerError::AccountIdDeserializationError)?;
 
     // Execute transaction
-    info!(target: COMPONENT, "Executing mint transaction for account.");
     let (executed_tx, created_note) = client.execute_mint_transaction(
         target_account_id,
         req.is_private_note,
@@ -84,7 +83,6 @@ pub async fn get_tokens(
         .context("Failed to apply faucet account delta")?;
 
     // Run transaction prover & send transaction to node
-    info!(target: COMPONENT, "Proving and submitting transaction.");
     let block_height = client.prove_and_submit_transaction(executed_tx).await?;
 
     // Update data store with the new faucet state

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -47,6 +47,7 @@ use crate::{
 
 const COMPONENT: &str = "miden-faucet";
 const FAUCET_CONFIG_FILE_PATH: &str = "miden-faucet.toml";
+const ENV_ENABLE_OTEL: &str = "MIDEN_NODE_ENABLE_OTEL"; // TODO(current pr): Should we consolidate this with bin/node/src/commands/mod.rs:14?
 
 // COMMANDS
 // ================================================================================================
@@ -64,6 +65,13 @@ pub enum Command {
     Start {
         #[arg(short, long, value_name = "FILE", default_value = FAUCET_CONFIG_FILE_PATH)]
         config: PathBuf,
+
+        /// Enables the exporting of traces for OpenTelemetry.
+        ///
+        /// This can be further configured using environment variables as defined in the official
+        /// OpenTelemetry documentation. See our operator manual for further details.
+        #[arg(long = "enable-otel", default_value_t = false, env = ENV_ENABLE_OTEL)]
+        open_telemetry: bool,
     },
 
     /// Create a new public faucet account and save to the specified file
@@ -89,22 +97,37 @@ pub enum Command {
     },
 }
 
+impl Command {
+    fn open_telemetry(&self) -> OpenTelemetry {
+        if match *self {
+            Command::Start { config: _, open_telemetry } => open_telemetry,
+            _ => false,
+        } {
+            OpenTelemetry::Enabled
+        } else {
+            OpenTelemetry::Disabled
+        }
+    }
+}
+
 // MAIN
 // =================================================================================================
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    miden_node_utils::logging::setup_tracing(OpenTelemetry::Disabled)
-        .context("failed to initialize logging")?;
-
     let cli = Cli::parse();
+
+    // Configure tracing with optional OpenTelemetry exporting support.
+    miden_node_utils::logging::setup_tracing(cli.command.open_telemetry())
+        .context("failed to initialize logging")?;
 
     run_faucet_command(cli).await
 }
 
 async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
     match &cli.command {
-        Command::Start { config } => {
+        // Note: open-telemetry is handled in main.
+        Command::Start { config, open_telemetry: _ } => {
             let config: FaucetConfig =
                 load_config(config).context("failed to load configuration file")?;
             let faucet_state = FaucetState::new(config.clone()).await?;
@@ -297,7 +320,10 @@ mod test {
         let website_url = config.endpoint.clone();
         tokio::spawn(async move {
             run_faucet_command(Cli {
-                command: crate::Command::Start { config: config_path },
+                command: crate::Command::Start {
+                    config: config_path,
+                    open_telemetry: false,
+                },
             })
             .await
             .unwrap();

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -47,7 +47,7 @@ use crate::{
 
 const COMPONENT: &str = "miden-faucet";
 const FAUCET_CONFIG_FILE_PATH: &str = "miden-faucet.toml";
-const ENV_ENABLE_OTEL: &str = "MIDEN_NODE_ENABLE_OTEL"; // TODO(current pr): Should we consolidate this with bin/node/src/commands/mod.rs:14?
+const ENV_ENABLE_OTEL: &str = "MIDEN_FAUCET_ENABLE_OTEL";
 
 // COMMANDS
 // ================================================================================================


### PR DESCRIPTION
Relates to #811.

### Changes
- Adds `--enable-otel` flag and `MIDEN_FAUCET_ENABLE_OTEL` to faucet.
- Adds instrumentation to functions in the faucet that pertain to RPC endpoints.

#### Endpoints with instrumentation:
<img width="1670" alt="Screenshot 2025-05-14 at 3 52 30 PM" src="https://github.com/user-attachments/assets/38df86a3-d6ee-45a6-babe-95647c6e3ca9" />

#### Endpoints without instrumentation:
<img width="1670" alt="Screenshot 2025-05-14 at 3 52 19 PM" src="https://github.com/user-attachments/assets/6d93be12-aa71-4503-9e81-ea0d0ac88ae2" />
