### PR TITLE
chore: migrate repository links from 0xPolygonMiden to 0xMiden

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -70,8 +70,8 @@ runs:
         Maintainer: Polygon Devops <devops@polygon.technology>
         Description: miden-node binary package
         Homepage: https://polygon.technology/polygon-miden
-        Vcs-Git: git@github.com:0xPolygonMiden/miden-node.git
-        Vcs-Browser: https://github.com/0xPolygonMiden/miden-node
+        Vcs-Git: git@github.com:0xMiden/miden-node.git
+        Vcs-Browser: https://github.com/0xMiden/miden-node
         EOF
 
         cat > packaging/deb/miden-faucet/DEBIAN/control << EOF
@@ -83,8 +83,8 @@ runs:
         Maintainer: Polygon Devops <devops@polygon.technology>
         Description: miden-faucet binary package
         Homepage: https://polygon.technology/polygon-miden
-        Vcs-Git: git@github.com:0xPolygonMiden/miden-node.git
-        Vcs-Browser: https://github.com/0xPolygonMiden/miden-node
+        Vcs-Git: git@github.com:0xMiden/miden-node.git
+        Vcs-Browser: https://github.com/0xMiden/miden-node
         EOF
 
     - name: Build binaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
 dependencies = [
  "async-trait",
  "getrandom 0.3.2",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#d1d4b34fdda523c6c7d5bbf2e5275dc9a46505e1"
 dependencies = [
  "miden-objects",
  "miden-tx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude      = [".github/"]
 homepage     = "https://polygon.technology/polygon-miden"
 license      = "MIT"
 readme       = "README.md"
-repository   = "https://github.com/0xPolygonMiden/miden-node"
+repository   = "https://github.com/0xMiden/miden-node"
 rust-version = "1.85"
 version      = "0.9.0"
 
@@ -35,7 +35,7 @@ assert_matches            = { version = "1.5" }
 http                      = { version = "1.3" }
 itertools                 = { version = "0.14" }
 miden-air                 = { version = "0.13" }
-miden-lib                 = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
+miden-lib                 = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.9" }
 miden-node-proto          = { path = "crates/proto", version = "0.9" }
 miden-node-proto-build    = { path = "proto", version = "0.9" }
@@ -43,9 +43,9 @@ miden-node-rpc            = { path = "crates/rpc", version = "0.9" }
 miden-node-store          = { path = "crates/store", version = "0.9" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.9" }
-miden-objects             = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
+miden-objects             = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
 miden-processor           = { version = "0.13" }
-miden-tx                  = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
+miden-tx                  = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
 thiserror                 = { version = "2.0", default-features = false }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -51,7 +51,7 @@ pub struct FaucetClient {
     rng: RpoRandomCoin,
 }
 
-// TODO: Remove this once https://github.com/0xPolygonMiden/miden-base/issues/909 is resolved
+// TODO: Remove this once https://github.com/0xMiden/miden-base/issues/909 is resolved
 unsafe impl Send for FaucetClient {}
 
 impl FaucetClient {

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -27,8 +27,8 @@ COPY --from=builder /usr/local/cargo/bin/miden-node /usr/local/bin/miden-node
 
 LABEL org.opencontainers.image.authors=miden@polygon.io \
       org.opencontainers.image.url=https://0xpolygonmiden.github.io/ \
-      org.opencontainers.image.documentation=https://github.com/0xPolygonMiden/miden-node \
-      org.opencontainers.image.source=https://github.com/0xPolygonMiden/miden-node \
+      org.opencontainers.image.documentation=https://github.com/0xMiden/miden-node \
+      org.opencontainers.image.source=https://github.com/0xMiden/miden-node \
       org.opencontainers.image.vendor=Polygon \
       org.opencontainers.image.licenses=MIT
 

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 clap = { version = "4.5", features = ["derive"] }
 futures = { version = "0.3" }
 miden-air = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", features = [
+miden-block-prover = { git = "https://github.com/0xMiden/miden-base.git", branch = "next", features = [
   "testing",
 ] }
 miden-lib = { workspace = true }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -16,20 +16,18 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
-futures = { version = "0.3" }
-miden-air = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xMiden/miden-base.git", branch = "next", features = [
-  "testing",
-] }
-miden-lib = { workspace = true }
+clap                      = { version = "4.5", features = ["derive"] }
+futures                   = { version = "0.3" }
+miden-air                 = { workspace = true }
+miden-block-prover        = { git = "https://github.com/0xMiden/miden-base.git", branch = "next", features = ["testing"] }
+miden-lib                 = { workspace = true }
 miden-node-block-producer = { workspace = true }
-miden-node-proto = { workspace = true }
-miden-node-store = { workspace = true }
-miden-node-utils = { workspace = true }
-miden-objects = { workspace = true, features = ["testing"] }
-rand = { workspace = true }
-rayon = { version = "1.5" }
-tokio = { workspace = true }
-tonic = { workspace = true }
-winterfell = { version = "0.12" }
+miden-node-proto          = { workspace = true }
+miden-node-store          = { workspace = true }
+miden-node-utils          = { workspace = true }
+miden-objects             = { workspace = true, features = ["testing"] }
+rand                      = { workspace = true }
+rayon                     = { version = "1.5" }
+tokio                     = { workspace = true }
+tonic                     = { workspace = true }
+winterfell                = { version = "0.12" }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -21,17 +21,17 @@ tracing-forest = ["miden-node-utils/tracing-forest"]
 anyhow = { workspace = true }
 futures = { version = "0.3" }
 itertools = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
+miden-block-prover = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
 miden-lib = { workspace = true }
 miden-node-proto = { workspace = true }
 miden-node-utils = { workspace = true, features = ["testing"] }
 miden-objects = { workspace = true }
 miden-processor = { workspace = true }
-miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", features = [
+miden-proving-service-client = { git = "https://github.com/0xMiden/miden-base.git", branch = "next", features = [
   "batch-prover",
   "block-prover",
 ] }
-miden-tx-batch-prover = { git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next" }
+miden-tx-batch-prover = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
 rand = { version = "0.9" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,7 @@ multilingual = false
 title        = "The Miden Node Operator and Developer Guide"
 
 [output.html]
-git-repository-url = "https://github.com/0xPolygonMiden/miden-node"
+git-repository-url = "https://github.com/0xMiden/miden-node"
 
 [preprocessor.katex]
 after = ["links"]


### PR DESCRIPTION
Hey team, I walked through the repo and swapped every `0xPolygonMiden` reference for `0xMiden`

Pure rename—no code or build behavior changed.
