### PR TITLE
fix: duplicated note ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Faucet now supports the usage of a remote transaction prover (#830).
+- [BUGFIX] Prevents duplicated note IDs (#842).
 
 ## v0.8.2 (2025-05-04)
 

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -28,7 +28,7 @@ miden-node-utils             = { workspace = true }
 miden-objects                = { workspace = true }
 miden-proving-service-client = { version = "0.8", features = ["tx-prover"] }
 miden-tx                     = { workspace = true, features = ["concurrent"] }
-rand                         = { workspace = true }
+rand                         = { workspace = true, features = ["thread_rng"] }
 rand_chacha                  = "0.9"
 serde                        = { version = "1.0", features = ["derive"] }
 serde_json                   = { version = "1.0" }

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -30,7 +30,7 @@ use miden_tx::{
 use rand::{random, rngs::StdRng};
 use serde::Serialize;
 use store::FaucetDataStore;
-use tokio::sync::{Mutex, mpsc::Receiver};
+use tokio::sync::mpsc::Receiver;
 use tonic::Code;
 use tracing::{error, info, instrument, warn};
 use updates::{ClientUpdater, MintUpdate, ResponseSender};
@@ -160,7 +160,6 @@ pub struct Faucet {
     tx_prover: Arc<FaucetProver>,
     tx_executor: Rc<TransactionExecutor>,
     account_interface: AccountInterface,
-    rng: Arc<Mutex<RpoRandomCoin>>,
 }
 
 impl Faucet {
@@ -243,9 +242,6 @@ impl Faucet {
         let tx_executor =
             Rc::new(TransactionExecutor::new(data_store.clone(), Some(authenticator.clone())));
 
-        let coin_seed: [u64; 4] = random();
-        let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
-
         Ok(Self {
             data_store,
             id,
@@ -253,7 +249,6 @@ impl Faucet {
             tx_prover,
             tx_executor,
             account_interface,
-            rng: Arc::new(Mutex::new(rng)),
         })
     }
 
@@ -383,10 +378,11 @@ impl Faucet {
         rpc_client: &mut RpcClient,
         updater: &ClientUpdater,
     ) -> MintResult<(AccountDelta, BlockNumber, Vec<Note>, TransactionId)> {
-        let p2id_notes = {
-            let mut rng_guard = self.rng.lock().await;
-            P2IdNotes::build(self.faucet_id(), requests, &mut rng_guard)?
-        };
+        let coin_seed: [u64; 4] = random();
+        let mut rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
+
+        let p2id_notes = P2IdNotes::build(self.faucet_id(), requests, &mut rng)?;
+
         // Build the note
         let notes = p2id_notes.into_inner();
         let tx_args = self.compile(&notes)?;

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -27,7 +27,7 @@ use miden_tx::{
     TransactionProver, TransactionProverError, auth::BasicAuthenticator,
     utils::parse_hex_string_as_word,
 };
-use rand::{random, rngs::StdRng, thread_rng};
+use rand::{Rng, rng, rngs::StdRng};
 use serde::Serialize;
 use store::FaucetDataStore;
 use tokio::sync::mpsc::Receiver;
@@ -378,7 +378,9 @@ impl Faucet {
         rpc_client: &mut RpcClient,
         updater: &ClientUpdater,
     ) -> MintResult<(AccountDelta, BlockNumber, Vec<Note>, TransactionId)> {
-        let coin_seed: [u64; 4] = random();
+        let mut thread_rng = rng();
+        let coin_seed: [u64; 4] = thread_rng.random();
+
         let mut rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
 
         let p2id_notes = P2IdNotes::build(self.faucet_id(), requests, &mut rng)?;

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -27,7 +27,7 @@ use miden_tx::{
     TransactionProver, TransactionProverError, auth::BasicAuthenticator,
     utils::parse_hex_string_as_word,
 };
-use rand::{random, rngs::StdRng};
+use rand::{random, rngs::StdRng, thread_rng};
 use serde::Serialize;
 use store::FaucetDataStore;
 use tokio::sync::mpsc::Receiver;


### PR DESCRIPTION
Closes #823 

The issue of the duplicated notes ID's had its origin in always using the same serial numbers for notes. That, generally, wasn't a problem because we were usually using different receiver IDs and asset amounts, and that modifies the final `NoteId`, but when repeating those values it was generating the error described in the issue.

The serial number was always the same because we were copying the Rng generator, thus always using the same inner index for the generator and getting the same value.