### PR TITLE
chore: fix clippy new warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -2622,6 +2622,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl"
 version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ miden-processor           = { version = "0.14" }
 miden-tx                  = { version = "0.9" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
-thiserror                 = { version = "2.0", default-features = false }
-tokio                     = { version = "1.44", features = ["rt-multi-thread"] }
+thiserror                 = { default-features = false, version = "2.0" }
+tokio                     = { features = ["rt-multi-thread"], version = "1.44" }
 tokio-stream              = { version = "0.1" }
 tonic                     = { version = "0.12" }
 tower                     = { version = "0.5" }
-tower-http                = { version = "0.6", features = ["trace"] }
+tower-http                = { features = ["trace"], version = "0.6" }
 tracing                   = { version = "0.1" }
-tracing-subscriber        = { version = "0.3", features = ["env-filter", "fmt", "json"] }
-url                       = { version = "2.5", features = ["serde"] }
+tracing-subscriber        = { features = ["env-filter", "fmt", "json"], version = "0.3" }
+url                       = { features = ["serde"], version = "2.5" }
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -16,46 +16,46 @@ workspace = true
 
 [dependencies]
 anyhow                       = { workspace = true }
-async-trait                  = "0.1"
-axum                         = { version = "0.8", features = ["tokio"] }
+async-trait                  = { version = "0.1" }
+axum                         = { features = ["tokio"], version = "0.8" }
 axum-extra                   = { version = "0.10" }
-base64                       = "0.22"
-clap                         = { version = "4.5", features = ["derive", "env", "string"] }
+base64                       = { version = "0.22" }
+clap                         = { features = ["derive", "env", "string"], version = "4.5" }
 http                         = { workspace = true }
 miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-rpc               = { workspace = true }
 miden-node-utils             = { workspace = true }
 miden-objects                = { workspace = true }
-miden-proving-service-client = { version = "0.9", features = ["tx-prover"] }
-miden-tx                     = { workspace = true, features = ["concurrent"] }
-rand                         = { workspace = true, features = ["thread_rng"] }
-rand_chacha                  = "0.9"
-serde                        = { version = "1.0", features = ["derive"] }
+miden-proving-service-client = { features = ["tx-prover"], version = "0.9" }
+miden-tx                     = { features = ["concurrent"], workspace = true }
+rand                         = { features = ["thread_rng"], workspace = true }
+rand_chacha                  = { version = "0.9" }
+serde                        = { features = ["derive"], version = "1.0" }
 serde_json                   = { version = "1.0" }
 sha3                         = { version = "0.10" }
 thiserror                    = { workspace = true }
-tokio                        = { workspace = true, features = ["fs"] }
-tokio-stream                 = { workspace = true, features = ["net"] }
+tokio                        = { features = ["fs"], workspace = true }
+tokio-stream                 = { features = ["net"], workspace = true }
 toml                         = { version = "0.8" }
-tonic                        = { workspace = true, features = ["tls-native-roots"] }
+tonic                        = { features = ["tls-native-roots"], workspace = true }
 tower                        = { workspace = true }
-tower-http                   = { workspace = true, features = ["cors", "set-header", "trace"] }
-tower_governor               = "0.7.0"
+tower-http                   = { features = ["cors", "set-header", "trace"], workspace = true }
+tower_governor               = { version = "0.7.0" }
 tracing                      = { workspace = true }
 url                          = { workspace = true }
 winter-maybe-async           = { version = "0.12" }
 
 [build-dependencies]
 # Required to inject build metadata.
-miden-node-utils = { workspace = true, features = ["vergen"] }
+miden-node-utils = { features = ["vergen"], workspace = true }
 
 [dev-dependencies]
 fantoccini                = { version = "0.21" }
-miden-node-block-producer = { workspace = true, features = ["testing"] }
-miden-objects             = { workspace = true, features = ["testing"] }
+miden-node-block-producer = { features = ["testing"], workspace = true }
+miden-objects             = { features = ["testing"], workspace = true }
 serde_json                = { version = "1.0" }
-tokio-stream              = { workspace = true, features = ["net"] }
+tokio-stream              = { features = ["net"], workspace = true }
 tonic-web                 = { version = "0.12" }
 
 # Required to avoid false positives in cargo-machete

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -139,7 +139,6 @@ type MintResult<T> = Result<T, MintError>;
 
 /// Error indicating what went wrong in the minting process for a request.
 #[derive(Debug, thiserror::Error)]
-#[allow(clippy::large_enum_variant)]
 pub enum MintError {
     #[error("compiling the tx script failed")]
     ScriptCompilation(#[source] AccountInterfaceError),
@@ -414,7 +413,6 @@ impl Faucet {
     }
 
     /// Compiles the transaction script that creates the given set of notes.
-    #[allow(clippy::result_large_err)]
     fn compile(&self, notes: &[Note]) -> MintResult<TransactionArgs> {
         let partial_notes = notes.iter().map(Into::into).collect::<Vec<_>>();
         let script = self
@@ -488,7 +486,6 @@ impl P2IdNotes {
     /// # Errors
     ///
     /// Returns an error if creating any p2id note fails.
-    #[allow(clippy::result_large_err)]
     fn build(
         source: FaucetId,
         requests: &[MintRequest],

--- a/bin/faucet/src/faucet/updates.rs
+++ b/bin/faucet/src/faucet/updates.rs
@@ -30,7 +30,7 @@ impl ClientUpdater {
     /// Sends an update to all the batch clients.
     /// Errors when sending through the channel are ignored since the client may have cancelled the
     /// request.
-    pub async fn send_updates(&self, update: MintUpdate) {
+    pub async fn send_updates(&self, update: MintUpdate<'_>) {
         let event = update.into_event();
         for sender in &self.clients {
             let _ = sender.send(Ok(event.clone())).await;
@@ -49,24 +49,23 @@ impl ClientUpdater {
     ) {
         for (note, sender) in notes.iter().zip(&self.clients) {
             let _ = sender
-                .send(Ok(MintUpdate::Minted(note.clone(), block_number, tx_id).into_event()))
+                .send(Ok(MintUpdate::Minted(note, block_number, tx_id).into_event()))
                 .await;
         }
     }
 }
 
 /// The different stages of the minting process.
-#[allow(clippy::large_enum_variant)]
-pub enum MintUpdate {
+pub enum MintUpdate<'a> {
     // TODO: add PoW verification event
     Built,
     Executed,
     Proven,
     Submitted,
-    Minted(Note, BlockNumber, TransactionId),
+    Minted(&'a Note, BlockNumber, TransactionId),
 }
 
-impl MintUpdate {
+impl MintUpdate<'_> {
     /// Converts the mint update into an sse event.
     /// Event types:
     /// - `MintUpdate::Built`: event type "update"

--- a/bin/faucet/src/rpc_client.rs
+++ b/bin/faucet/src/rpc_client.rs
@@ -18,7 +18,7 @@ use crate::faucet::FaucetId;
 #[derive(Debug, thiserror::Error)]
 pub enum RpcError {
     #[error("gRPC error encountered")]
-    Transport(#[source] tonic::Status),
+    Transport(#[source] Box<tonic::Status>),
     #[error("error parsing the gRPC response")]
     ResponseParsing(#[source] anyhow::Error),
 }
@@ -46,7 +46,7 @@ impl RpcClient {
             .inner
             .get_block_header_by_number(request)
             .await
-            .map_err(RpcError::Transport)?;
+            .map_err(|e| RpcError::Transport(Box::new(e)))?;
 
         let root_block_header = response
             .into_inner()
@@ -70,7 +70,7 @@ impl RpcClient {
             .inner
             .get_account_details(request)
             .await
-            .map_err(RpcError::Transport)?
+            .map_err(|e| RpcError::Transport(Box::new(e)))?
             .into_inner()
             .details
             .context("details field is missing")
@@ -97,6 +97,6 @@ impl RpcClient {
             .submit_proven_transaction(request)
             .await
             .map(|response| response.into_inner().block_height.into())
-            .map_err(RpcError::Transport)
+            .map_err(|e| RpcError::Transport(Box::new(e)))
     }
 }

--- a/bin/faucet/src/rpc_client.rs
+++ b/bin/faucet/src/rpc_client.rs
@@ -46,7 +46,7 @@ impl RpcClient {
             .inner
             .get_block_header_by_number(request)
             .await
-            .map_err(|e| RpcError::Transport(Box::new(e)))?;
+            .map_err(|e| RpcError::Transport(e.into()))?;
 
         let root_block_header = response
             .into_inner()
@@ -70,7 +70,7 @@ impl RpcClient {
             .inner
             .get_account_details(request)
             .await
-            .map_err(|e| RpcError::Transport(Box::new(e)))?
+            .map_err(|e| RpcError::Transport(e.into()))?
             .into_inner()
             .details
             .context("details field is missing")
@@ -97,6 +97,6 @@ impl RpcClient {
             .submit_proven_transaction(request)
             .await
             .map(|response| response.into_inner().block_height.into())
-            .map_err(|e| RpcError::Transport(Box::new(e)))
+            .map_err(|e| RpcError::Transport(e.into()))
     }
 }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -19,7 +19,7 @@ tracing-forest = ["miden-node-block-producer/tracing-forest"]
 
 [dependencies]
 anyhow                    = { workspace = true }
-clap                      = { version = "4.5", features = ["derive", "env", "string"] }
+clap                      = { features = ["derive", "env", "string"], version = "4.5" }
 miden-lib                 = { workspace = true }
 miden-node-block-producer = { workspace = true }
 miden-node-rpc            = { workspace = true }
@@ -29,14 +29,14 @@ miden-objects             = { workspace = true }
 rand                      = { workspace = true }
 rand_chacha               = { version = "0.9" }
 sysinfo                   = { version = "0.35" }
-tokio                     = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+tokio                     = { features = ["macros", "net", "rt-multi-thread"], workspace = true }
 tracing                   = { workspace = true }
 url                       = { workspace = true }
 
 [dev-dependencies]
-figment          = { version = "0.10", features = ["env", "test", "toml"] }
-miden-node-utils = { workspace = true, features = ["tracing-forest"] }
+figment          = { features = ["env", "test", "toml"], version = "0.10" }
+miden-node-utils = { features = ["tracing-forest"], workspace = true }
 
 [build-dependencies]
 # Required to inject build metadata.
-miden-node-utils = { workspace = true, features = ["vergen"] }
+miden-node-utils = { features = ["vergen"], workspace = true }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -16,16 +16,16 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
-clap                      = { version = "4.5", features = ["derive"] }
+clap                      = { features = ["derive"], version = "4.5" }
 futures                   = { version = "0.3" }
 miden-air                 = { workspace = true }
-miden-block-prover        = { version = "0.9", features = ["testing"] }
+miden-block-prover        = { features = ["testing"], version = "0.9" }
 miden-lib                 = { workspace = true }
 miden-node-block-producer = { workspace = true }
 miden-node-proto          = { workspace = true }
 miden-node-store          = { workspace = true }
 miden-node-utils          = { workspace = true }
-miden-objects             = { workspace = true, features = ["testing"] }
+miden-objects             = { features = ["testing"], workspace = true }
 rand                      = { workspace = true }
 rayon                     = { version = "1.5" }
 tokio                     = { workspace = true }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -25,33 +25,33 @@ itertools                    = { workspace = true }
 miden-block-prover           = { version = "0.9" }
 miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
-miden-node-utils             = { workspace = true, features = ["testing"] }
+miden-node-utils             = { features = ["testing"], workspace = true }
 miden-objects                = { workspace = true }
 miden-processor              = { workspace = true }
-miden-proving-service-client = { version = "0.9", features = ["batch-prover", "block-prover"] }
+miden-proving-service-client = { features = ["batch-prover", "block-prover"], version = "0.9" }
 miden-tx                     = { workspace = true }
 miden-tx-batch-prover        = { version = "0.9" }
 rand                         = { version = "0.9" }
 thiserror                    = { workspace = true }
-tokio                        = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tokio-stream                 = { workspace = true, features = ["net"] }
-tonic                        = { workspace = true, features = ["transport"] }
-tower-http                   = { workspace = true, features = ["util"] }
+tokio                        = { features = ["macros", "net", "rt-multi-thread", "sync", "time"], workspace = true }
+tokio-stream                 = { features = ["net"], workspace = true }
+tonic                        = { features = ["transport"], workspace = true }
+tower-http                   = { features = ["util"], workspace = true }
 tracing                      = { workspace = true }
 url                          = { workspace = true }
 
 [dev-dependencies]
 assert_matches        = { workspace = true }
 miden-air             = { workspace = true }
-miden-lib             = { workspace = true, features = ["testing"] }
+miden-lib             = { features = ["testing"], workspace = true }
 miden-node-store      = { workspace = true }
 miden-node-test-macro = { workspace = true }
-miden-node-utils      = { workspace = true, features = ["testing"] }
-miden-objects         = { workspace = true, features = ["testing"] }
-miden-tx              = { workspace = true, features = ["testing"] }
+miden-node-utils      = { features = ["testing"], workspace = true }
+miden-objects         = { features = ["testing"], workspace = true }
+miden-tx              = { features = ["testing"], workspace = true }
 pretty_assertions     = "1.4"
-rand_chacha           = { version = "0.9", default-features = false }
+rand_chacha           = { default-features = false, version = "0.9" }
 serial_test           = "3.2"
 tempfile              = { version = "3.5" }
-tokio                 = { workspace = true, features = ["test-util"] }
+tokio                 = { features = ["test-util"], workspace = true }
 winterfell            = { version = "0.12" }

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -45,7 +45,6 @@ impl AuthenticatedTransaction {
     /// # Errors
     ///
     /// Returns an error if any of the transaction's nullifiers are marked as spent by the inputs.
-    #[allow(clippy::result_large_err)]
     pub fn new(
         tx: ProvenTransaction,
         inputs: TransactionInputs,

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -191,6 +191,6 @@ pub enum StoreError {
 
 impl From<tonic::Status> for StoreError {
     fn from(value: tonic::Status) -> Self {
-        StoreError::GrpcClientError(Box::new(value))
+        StoreError::GrpcClientError(value.into())
     }
 }

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -182,9 +182,15 @@ pub enum BuildBlockError {
 #[derive(Debug, Error)]
 pub enum StoreError {
     #[error("gRPC client error")]
-    GrpcClientError(#[from] tonic::Status),
+    GrpcClientError(Box<tonic::Status>),
     #[error("malformed response from store: {0}")]
     MalformedResponse(String),
     #[error("failed to parse response")]
     DeserializationError(#[from] ConversionError),
+}
+
+impl From<tonic::Status> for StoreError {
+    fn from(value: tonic::Status) -> Self {
+        StoreError::GrpcClientError(Box::new(value))
+    }
 }

--- a/crates/block-producer/src/mempool/inflight_state/mod.rs
+++ b/crates/block-producer/src/mempool/inflight_state/mod.rs
@@ -104,7 +104,6 @@ impl InflightState {
     /// Appends the transaction to the inflight state.
     ///
     /// This operation is atomic i.e. a rejected transaction has no impact of the state.
-    #[allow(clippy::result_large_err)]
     pub fn add_transaction(
         &mut self,
         tx: &AuthenticatedTransaction,
@@ -129,7 +128,6 @@ impl InflightState {
             .expect("Chain height cannot be less than number of committed blocks")
     }
 
-    #[allow(clippy::result_large_err)]
     fn verify_transaction(&self, tx: &AuthenticatedTransaction) -> Result<(), AddTransactionError> {
         // Check that the transaction hasn't already expired.
         if tx.expires_at() <= self.chain_tip + self.expiration_slack {

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -27,7 +27,7 @@ proptest = { version = "1.5" }
 
 [build-dependencies]
 anyhow                 = { workspace = true }
-miden-node-proto-build = { workspace = true, features = ["internal"] }
+miden-node-proto-build = { features = ["internal"], workspace = true }
 prost                  = { workspace = true }
 prost-build            = { version = "0.13" }
 protox                 = { version = "0.8" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -24,17 +24,17 @@ miden-objects    = { workspace = true }
 miden-tx         = { workspace = true }
 nom              = { version = "8.0" }
 semver           = { version = "1.0" }
-tokio            = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
-tokio-stream     = { workspace = true, features = ["net"] }
+tokio            = { features = ["macros", "net", "rt-multi-thread"], workspace = true }
+tokio-stream     = { features = ["net"], workspace = true }
 tonic            = { workspace = true }
 tonic-web        = { version = "0.12" }
 tower            = { workspace = true }
-tower-http       = { workspace = true, features = ["trace"] }
+tower-http       = { features = ["trace"], workspace = true }
 tracing          = { workspace = true }
 url              = { workspace = true }
 
 [dev-dependencies]
 miden-node-rpc   = { workspace = true }
 miden-node-store = { workspace = true }
-miden-node-utils = { workspace = true, features = ["tracing-forest"] }
+miden-node-utils = { features = ["tracing-forest"], workspace = true }
 tempfile         = { version = "3.5" }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -16,28 +16,28 @@ workspace = true
 
 [dependencies]
 anyhow             = { workspace = true }
-deadpool           = { version = "0.12", features = ["managed", "rt_tokio_1"], default-features = false }
+deadpool           = { default-features = false, features = ["managed", "rt_tokio_1"], version = "0.12" }
 deadpool-sync      = { version = "0.1" }
 hex                = { version = "0.4" }
 miden-lib          = { workspace = true }
 miden-node-proto   = { workspace = true }
 miden-node-utils   = { workspace = true }
 miden-objects      = { workspace = true }
-rusqlite           = { version = "0.35", features = ["array", "buildtime_bindgen", "bundled"] }
+rusqlite           = { features = ["array", "buildtime_bindgen", "bundled"], version = "0.35" }
 rusqlite_migration = { version = "2.1" }
 thiserror          = { workspace = true }
-tokio              = { workspace = true, features = ["fs", "macros", "net", "rt-multi-thread"] }
-tokio-stream       = { workspace = true, features = ["net"] }
+tokio              = { features = ["fs", "macros", "net", "rt-multi-thread"], workspace = true }
+tokio-stream       = { features = ["net"], workspace = true }
 tonic              = { workspace = true }
-tower-http         = { workspace = true, features = ["util"] }
+tower-http         = { features = ["util"], workspace = true }
 tracing            = { workspace = true }
 
 [dev-dependencies]
 assert_matches        = { workspace = true }
-miden-lib             = { workspace = true, features = ["testing"] }
+miden-lib             = { features = ["testing"], workspace = true }
 miden-node-test-macro = { workspace = true }
-miden-node-utils      = { workspace = true, features = ["tracing-forest"] }
-miden-objects         = { workspace = true, features = ["testing"] }
+miden-node-utils      = { features = ["tracing-forest"], workspace = true }
+miden-objects         = { features = ["testing"], workspace = true }
 rand                  = { version = "0.9" }
 regex                 = { version = "1.11" }
 termtree              = { version = "0.5" }

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -283,7 +283,7 @@ impl api_server::Api for StoreApi {
         request: Request<GetAccountDetailsRequest>,
     ) -> Result<Response<GetAccountDetailsResponse>, Status> {
         let request = request.into_inner();
-        let account_id = read_account_id(request.account_id)?;
+        let account_id = read_account_id(request.account_id).map_err(|err| *err)?;
         let account_info: AccountInfo = self.state.get_account_details(account_id).await?;
 
         Ok(Response::new(GetAccountDetailsResponse {
@@ -406,7 +406,7 @@ impl api_server::Api for StoreApi {
 
         debug!(target: COMPONENT, ?request);
 
-        let account_id = read_account_id(request.account_id)?;
+        let account_id = read_account_id(request.account_id).map_err(|err| *err)?;
         let nullifiers = validate_nullifiers(&request.nullifiers)?;
         let unauthenticated_notes = validate_notes(&request.unauthenticated_notes)?;
 
@@ -512,7 +512,7 @@ impl api_server::Api for StoreApi {
 
         debug!(target: COMPONENT, ?request);
 
-        let account_id = read_account_id(request.account_id)?;
+        let account_id = read_account_id(request.account_id).map_err(|err| *err)?;
         let delta = self
             .state
             .get_account_state_delta(
@@ -582,15 +582,13 @@ fn invalid_argument<E: core::fmt::Display>(err: E) -> Status {
     Status::invalid_argument(err.to_string())
 }
 
-#[allow(clippy::result_large_err)]
-fn read_account_id(id: Option<generated::account::AccountId>) -> Result<AccountId, Status> {
+fn read_account_id(id: Option<generated::account::AccountId>) -> Result<AccountId, Box<Status>> {
     id.ok_or(invalid_argument("missing account ID"))?
         .try_into()
-        .map_err(|err| invalid_argument(format!("invalid account ID: {err}")))
+        .map_err(|err| Box::new(invalid_argument(format!("invalid account ID: {err}"))))
 }
 
 #[instrument(target = COMPONENT, skip_all, err)]
-#[allow(clippy::result_large_err)]
 fn read_account_ids(
     account_ids: &[generated::account::AccountId],
 ) -> Result<Vec<AccountId>, Status> {

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -585,7 +585,7 @@ fn invalid_argument<E: core::fmt::Display>(err: E) -> Status {
 fn read_account_id(id: Option<generated::account::AccountId>) -> Result<AccountId, Box<Status>> {
     id.ok_or(invalid_argument("missing account ID"))?
         .try_into()
-        .map_err(|err| Box::new(invalid_argument(format!("invalid account ID: {err}"))))
+        .map_err(|err| invalid_argument(format!("invalid account ID: {err}")).into())
 }
 
 #[instrument(target = COMPONENT, skip_all, err)]

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 quote = { version = "1.0" }
-syn   = { version = "2.0", features = ["extra-traits", "full"] }
+syn   = { features = ["extra-traits", "full"], version = "2.0" }
 
 [lib]
 proc-macro = true

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -22,18 +22,18 @@ testing = ["dep:tokio"]
 
 [dependencies]
 anyhow                = { workspace = true }
-figment               = { version = "0.10", features = ["env", "toml"] }
+figment               = { features = ["env", "toml"], version = "0.10" }
 http                  = { workspace = true }
 itertools             = { workspace = true }
 miden-objects         = { workspace = true }
 opentelemetry         = { version = "0.29" }
-opentelemetry-otlp    = { version = "0.29", default-features = false, features = ["grpc-tonic", "tls-roots", "trace"] }
-opentelemetry_sdk     = { version = "0.29", features = ["rt-tokio", "testing"] }
+opentelemetry-otlp    = { default-features = false, features = ["grpc-tonic", "tls-roots", "trace"], version = "0.29" }
+opentelemetry_sdk     = { features = ["rt-tokio", "testing"], version = "0.29" }
 rand                  = { workspace = true }
-serde                 = { version = "1.0", features = ["derive"] }
+serde                 = { features = ["derive"], version = "1.0" }
 tonic                 = { workspace = true }
 tracing               = { workspace = true }
-tracing-forest        = { version = "0.1", optional = true, features = ["chrono"] }
+tracing-forest        = { features = ["chrono"], optional = true, version = "0.1" }
 tracing-opentelemetry = { version = "0.30" }
 tracing-subscriber    = { workspace = true }
 url                   = { workspace = true }
@@ -41,6 +41,6 @@ url                   = { workspace = true }
 # Optional dependencies enabled by `vergen` feature.
 # This must match the version expected by `vergen-gitcl`.
 vergen       = { "version" = "9.0", optional = true }
-vergen-gitcl = { version = "1.0", features = ["cargo", "rustc"], optional = true }
+vergen-gitcl = { features = ["cargo", "rustc"], optional = true, version = "1.0" }
 # Optional dependencies enabled by `testing` feature.
-tokio = { workspace = true, optional = true }
+tokio = { optional = true, workspace = true }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
 /// relative, searches in parent directories all the way to the root as well.
 ///
 /// The above configuration options are indented to support easy of packaging and deployment.
-#[allow(clippy::result_large_err)]
+#[allow(clippy::result_large_err, reason = "This error crashes the node")]
 pub fn load_config<T: for<'a> Deserialize<'a>>(
     config_file: impl AsRef<Path>,
 ) -> figment::Result<T> {


### PR DESCRIPTION
Closes https://github.com/0xMiden/miden-node/issues/855.

This PR removes the clippy allows that were added as a hotfix for the new clippy warnings. 
For addressing them, this PR boxes the `tonic::Status` struct when used in error variants and changes some error handling to account for it.