### PR TITLE
fix(temporary): enums too large

### DIFF
--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -138,6 +138,7 @@ type MintResult<T> = Result<T, MintError>;
 
 /// Error indicating what went wrong in the minting process for a request.
 #[derive(Debug, thiserror::Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum MintError {
     #[error("compiling the tx script failed")]
     ScriptCompilation(#[source] AccountInterfaceError),
@@ -405,6 +406,7 @@ impl Faucet {
     }
 
     /// Compiles the transaction script that creates the given set of notes.
+    #[allow(clippy::result_large_err)]
     fn compile(&self, notes: &[Note]) -> MintResult<TransactionArgs> {
         let partial_notes = notes.iter().map(Into::into).collect::<Vec<_>>();
         let script = self
@@ -471,6 +473,7 @@ impl P2IdNotes {
     /// # Errors
     ///
     /// Returns an error if creating any p2id note fails.
+    #[allow(clippy::result_large_err)]
     fn build(
         source: FaucetId,
         requests: &[MintRequest],

--- a/bin/faucet/src/faucet/updates.rs
+++ b/bin/faucet/src/faucet/updates.rs
@@ -56,6 +56,7 @@ impl ClientUpdater {
 }
 
 /// The different stages of the minting process.
+#[allow(clippy::large_enum_variant)]
 pub enum MintUpdate {
     // TODO: add PoW verification event
     Built,

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -207,7 +207,7 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
             std::fs::write(&config_file_path, config_as_toml_string)
                 .context("error writing config to file")?;
 
-            println!("Config file successfully created at: {config_file_path:?}");
+            println!("Config file successfully created at: {}", config_file_path.display());
         },
     }
 

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -45,6 +45,7 @@ impl AuthenticatedTransaction {
     /// # Errors
     ///
     /// Returns an error if any of the transaction's nullifiers are marked as spent by the inputs.
+    #[allow(clippy::result_large_err)]
     pub fn new(
         tx: ProvenTransaction,
         inputs: TransactionInputs,

--- a/crates/block-producer/src/mempool/inflight_state/mod.rs
+++ b/crates/block-producer/src/mempool/inflight_state/mod.rs
@@ -104,6 +104,7 @@ impl InflightState {
     /// Appends the transaction to the inflight state.
     ///
     /// This operation is atomic i.e. a rejected transaction has no impact of the state.
+    #[allow(clippy::result_large_err)]
     pub fn add_transaction(
         &mut self,
         tx: &AuthenticatedTransaction,
@@ -128,6 +129,7 @@ impl InflightState {
             .expect("Chain height cannot be less than number of committed blocks")
     }
 
+    #[allow(clippy::result_large_err)]
     fn verify_transaction(&self, tx: &AuthenticatedTransaction) -> Result<(), AddTransactionError> {
         // Check that the transaction hasn't already expired.
         if tx.expires_at() <= self.chain_tip + self.expiration_slack {

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -534,6 +534,7 @@ fn invalid_argument<E: core::fmt::Display>(err: E) -> Status {
     Status::invalid_argument(err.to_string())
 }
 
+#[allow(clippy::result_large_err)]
 fn read_account_id(id: Option<generated::account::AccountId>) -> Result<AccountId, Status> {
     id.ok_or(invalid_argument("missing account ID"))?
         .try_into()
@@ -541,6 +542,7 @@ fn read_account_id(id: Option<generated::account::AccountId>) -> Result<AccountI
 }
 
 #[instrument(target = COMPONENT, skip_all, err)]
+#[allow(clippy::result_large_err)]
 fn read_account_ids(
     account_ids: &[generated::account::AccountId],
 ) -> Result<Vec<AccountId>, Status> {

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_FAUCET_SERVER_PORT: u16 = 8080;
 /// relative, searches in parent directories all the way to the root as well.
 ///
 /// The above configuration options are indented to support easy of packaging and deployment.
+#[allow(clippy::result_large_err)]
 pub fn load_config<T: for<'a> Deserialize<'a>>(
     config_file: impl AsRef<Path>,
 ) -> figment::Result<T> {


### PR DESCRIPTION
Currently, all the PRs are failing in the lint step because of the new rust version. In next is being fixed with https://github.com/0xMiden/miden-node/pull/850 , and looks like it is going to be a more definitive solution, boxing large variants. I created this PR with lint `allow`s so we can unlock the faucet PRs that use main as base. 