### PR TITLE
fix: run `cargo update` and fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -1796,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2173,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2203,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#a30142d0653ff833af501179fb3ccbc9e98767ae"
+source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2599,9 +2599,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
@@ -4649,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -4662,12 +4662,13 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
  "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4710,18 +4711,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
 dependencies = [
  "windows-link",
 ]
@@ -4798,6 +4799,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -19,7 +19,7 @@ use miden_objects::{
     },
     note::{Note, NoteType},
     transaction::{
-        ExecutedTransaction, ForeignAccountInputs, InputNote, InputNotes, PartialBlockchain,
+        AccountInputs, ExecutedTransaction, InputNote, InputNotes, PartialBlockchain,
         TransactionArgs, TransactionScript,
     },
     utils::Deserializable,
@@ -297,12 +297,8 @@ fn build_transaction_arguments(
     let script = TransactionScript::compile(script, vec![], TransactionKernel::assembler())
         .context("Failed to compile script")?;
 
-    let mut transaction_args = TransactionArgs::new(
-        Some(script),
-        None,
-        AdviceMap::new(),
-        Vec::<ForeignAccountInputs>::default(),
-    );
+    let mut transaction_args =
+        TransactionArgs::new(Some(script), None, AdviceMap::new(), Vec::<AccountInputs>::default());
     transaction_args.extend_output_note_recipients(vec![output_note.clone()]);
 
     Ok(transaction_args)

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -281,7 +281,7 @@ mod test {
     use miden_node_store::{GenesisState, Store};
     use miden_objects::{
         Digest,
-        account::{AccountId, AccountIdVersion, AccountStorageMode, AccountType, NetworkAccount},
+        account::{AccountId, AccountIdVersion, AccountStorageMode, AccountType},
         transaction::ProvenTransactionBuilder,
     };
     use miden_tx::utils::Serializable;
@@ -403,7 +403,6 @@ mod test {
                 AccountIdVersion::Version0,
                 AccountType::RegularAccountImmutableCode,
                 AccountStorageMode::Private,
-                NetworkAccount::Disabled,
             ),
             Digest::default(),
             [i; 32].try_into().unwrap(),

--- a/crates/block-producer/src/test_utils/account.rs
+++ b/crates/block-producer/src/test_utils/account.rs
@@ -2,10 +2,7 @@ use std::{collections::HashMap, ops::Not, sync::LazyLock};
 
 use miden_objects::{
     Digest, Hasher,
-    account::{
-        AccountId, AccountIdAnchor, AccountIdVersion, AccountStorageMode, AccountType,
-        NetworkAccount,
-    },
+    account::{AccountId, AccountIdAnchor, AccountIdVersion, AccountStorageMode, AccountType},
 };
 
 pub static MOCK_ACCOUNTS: LazyLock<std::sync::Mutex<HashMap<u32, (AccountId, Digest)>>> =
@@ -39,7 +36,6 @@ impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
             init_seed,
             AccountType::RegularAccountUpdatableCode,
             AccountStorageMode::Private,
-            NetworkAccount::Disabled,
             AccountIdVersion::Version0,
             Digest::default(),
             Digest::default(),

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -12,8 +12,8 @@ use miden_objects::{
     Felt, FieldElement, Word, ZERO,
     account::{
         Account, AccountBuilder, AccountComponent, AccountDelta, AccountId, AccountIdVersion,
-        AccountStorageDelta, AccountStorageMode, AccountType, AccountVaultDelta, NetworkAccount,
-        StorageSlot, delta::AccountUpdateDetails,
+        AccountStorageDelta, AccountStorageMode, AccountType, AccountVaultDelta, StorageSlot,
+        delta::AccountUpdateDetails,
     },
     asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree, BlockNumber},
@@ -369,8 +369,7 @@ fn sql_unconsumed_network_notes() {
 
     let account = mock_account_code_and_storage(
         AccountType::RegularAccountUpdatableCode,
-        AccountStorageMode::Public,
-        NetworkAccount::Enabled,
+        AccountStorageMode::Network,
         [],
     );
     let account_id = account.id();
@@ -494,7 +493,6 @@ fn sql_select_accounts() {
             AccountIdVersion::Version0,
             AccountType::RegularAccountImmutableCode,
             AccountStorageMode::Private,
-            NetworkAccount::Disabled,
         );
         let account_commitment = num_to_rpo_digest(u64::from(i));
         state.push(AccountInfo {
@@ -544,7 +542,6 @@ fn sql_public_account_details() {
     let mut account = mock_account_code_and_storage(
         AccountType::RegularAccountImmutableCode,
         AccountStorageMode::Public,
-        NetworkAccount::Disabled,
         [Asset::Fungible(FungibleAsset::new(fungible_faucet_id, 150).unwrap()), nft1],
     );
 
@@ -1195,7 +1192,6 @@ fn insert_transactions(conn: &mut Connection) -> usize {
 fn mock_account_code_and_storage(
     account_type: AccountType,
     storage_mode: AccountStorageMode,
-    network: NetworkAccount,
     assets: impl IntoIterator<Item = Asset>,
 ) -> Account {
     let component_code = "\
@@ -1224,7 +1220,6 @@ fn mock_account_code_and_storage(
 
     AccountBuilder::new([0; 32])
         .account_type(account_type)
-        .network_account(network)
         .storage_mode(storage_mode)
         .with_assets(assets)
         .with_component(component)

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -858,7 +858,7 @@ impl State {
 
                     let state_header = AccountStateHeader {
                         header: Some(AccountHeader::from(details).into()),
-                        storage_header: details.storage().get_header().to_bytes(),
+                        storage_header: details.storage().to_header().to_bytes(),
                         account_code,
                         storage_maps: storage_slot_map_keys,
                     };


### PR DESCRIPTION
Update needed to fix client's CI. Updates `miden-base`, removing the old `NetworkAccount` enum.