### PR TITLE
feat: update miden crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1375,9 +1375,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -1765,9 +1765,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miden-air"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2e77c57ae798e02553af158c04d467f6479ab798a8c84459d343a89ff9c50"
+checksum = "71f9878c75891951ac4e8dd42793a84c4d07e5aaf27a8c88bfc097b70cd2c1cd"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d1cb02d807c2481f365feca966bedb74c66c765923d04c3c23ea678afaf148"
+checksum = "b4e3d328e85faa193464dff6b51d9a6ede860a0a0b91858f2370931346d67c26"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1796,7 +1796,8 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d59a53f9ff3585d1a3a9b9432b949397a014ffa6f9092cab2bd92528a0e382"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -1805,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d408e01421b5df2e4cfaf1a91efefe3fb5b729f1c99b668d3a69eec0044a6b"
+checksum = "134f716ca140dd0e89f5c96527c3554be1f0289f2519c905ac83a48f8db899a8"
 dependencies = [
  "lock_api",
  "loom",
@@ -1888,7 +1889,8 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb98502ec0b2fb58846cdecbaefd7dc1e1655d86c2302c28a3f80a470cdd1d4"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2127,8 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b4c5d037aa609fb247141a0707f0012a12ff7e14bba350b6f119a2010a65f9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2148,12 +2151,13 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e70b053c587014396d06be3502e3952777923bee11729b7514c060fdc0d2c8"
+checksum = "2796a5c11589731286ca1cb761b13be13e69e4e0606a5469ce815491989402ea"
 dependencies = [
  "miden-air",
  "miden-core",
+ "miden-miette",
  "thiserror 2.0.12",
  "tracing",
  "winter-prover",
@@ -2161,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baa571449e7811e934dae919285dfea4854fb867f6d20d757d60b0601ef0140"
+checksum = "89bc4b989306ca1b8bdba364af72547c563419e77220f4cd244ed2bf3557d351"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -2175,7 +2179,8 @@ dependencies = [
 [[package]]
 name = "miden-proving-service-client"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbd9676d8f6e8b9cbeba33a1c7fb115ef376d2f4101a5f97b5572ce9e10fb47"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
@@ -2194,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e59c4dd1079bffe8407694b386ae781feaf1f7acb9d1cefa858578bc99cad4"
+checksum = "887189ccce4f9bbf15dfdaff0e6842fb138a7432a8f21adde756fac114b07184"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2205,7 +2210,8 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbea7c2a870e69e86e4d7bdf21936447552442f4ec274e499d2d9b8a90a70653"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2221,7 +2227,8 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.9.0"
-source = "git+https://github.com/0xMiden/miden-base.git?branch=next#3d8c3b28048fffbb63592a971d0fcae5dc58bce9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec59ad67da64407aeb62ca248b09289d32defe70d724484e137652a40f9f74"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2229,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ae024b022569d7117891a83cf51ccd5bceeda248f30690b394a6dfc4607061"
+checksum = "a2b6edc80bf70f276be1c001748c1edf10bea6273a57ee3694fd73d79050fc09"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2917,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb644dd3ad12d7cf62a18234d385ea5511ac6abb208704c18098e7e3a5e1b69"
+checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
 dependencies = [
  "logos 0.15.0",
  "miette",
@@ -2960,7 +2967,7 @@ dependencies = [
  "bytes",
  "miette",
  "prost",
- "prost-reflect 0.15.2",
+ "prost-reflect 0.15.3",
  "prost-types",
  "protox-parse 0.8.0",
  "thiserror 2.0.12",
@@ -3708,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b897c8ea620e181c7955369a31be5f48d9a9121cb59fd33ecef9ff2a34323422"
+checksum = "79251336d17c72d9762b8b54be4befe38d2db56fbbc0241396d70f173c39d47a"
 dependencies = [
  "libc",
  "memchr",
@@ -4693,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -4755,18 +4762,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ anyhow                    = { version = "1.0" }
 assert_matches            = { version = "1.5" }
 http                      = { version = "1.3" }
 itertools                 = { version = "0.14" }
-miden-air                 = { version = "0.13" }
-miden-lib                 = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
+miden-air                 = { version = "0.14" }
+miden-lib                 = { version = "0.9" }
 miden-node-block-producer = { path = "crates/block-producer", version = "0.9" }
 miden-node-proto          = { path = "crates/proto", version = "0.9" }
 miden-node-proto-build    = { path = "proto", version = "0.9" }
@@ -43,9 +43,9 @@ miden-node-rpc            = { path = "crates/rpc", version = "0.9" }
 miden-node-store          = { path = "crates/store", version = "0.9" }
 miden-node-test-macro     = { path = "crates/test-macro" }
 miden-node-utils          = { path = "crates/utils", version = "0.9" }
-miden-objects             = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
-miden-processor           = { version = "0.13" }
-miden-tx                  = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
+miden-objects             = { version = "0.9" }
+miden-processor           = { version = "0.14" }
+miden-tx                  = { version = "0.9" }
 prost                     = { version = "0.13" }
 rand                      = { version = "0.9" }
 thiserror                 = { version = "2.0", default-features = false }

--- a/bin/faucet/src/client.rs
+++ b/bin/faucet/src/client.rs
@@ -11,6 +11,7 @@ use miden_node_proto::generated::{
 use miden_objects::{
     Felt,
     account::{Account, AccountFile, AccountId, AuthSecretKey},
+    assembly::DefaultSourceManager,
     asset::FungibleAsset,
     block::{BlockHeader, BlockNumber},
     crypto::{
@@ -158,6 +159,7 @@ impl FaucetClient {
                 0.into(),
                 InputNotes::<InputNote>::default(),
                 transaction_args,
+                Arc::new(DefaultSourceManager::default()),
             )
             .context("Failed to execute transaction")?;
 

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86-slim-bullseye AS builder
+FROM rust:1.87-slim-bullseye AS builder
 
 RUN apt-get update && \
     apt-get -y upgrade && \
@@ -27,18 +27,18 @@ COPY --from=builder /app/data data
 COPY --from=builder /usr/local/cargo/bin/miden-node /usr/local/bin/miden-node
 
 LABEL org.opencontainers.image.authors=miden@polygon.io \
-      org.opencontainers.image.url=https://0xpolygonmiden.github.io/ \
-      org.opencontainers.image.documentation=https://github.com/0xMiden/miden-node \
-      org.opencontainers.image.source=https://github.com/0xMiden/miden-node \
-      org.opencontainers.image.vendor=Polygon \
-      org.opencontainers.image.licenses=MIT
+    org.opencontainers.image.url=https://0xpolygonmiden.github.io/ \
+    org.opencontainers.image.documentation=https://github.com/0xMiden/miden-node \
+    org.opencontainers.image.source=https://github.com/0xMiden/miden-node \
+    org.opencontainers.image.vendor=Polygon \
+    org.opencontainers.image.licenses=MIT
 
 ARG CREATED
 ARG VERSION
 ARG COMMIT
 LABEL org.opencontainers.image.created=$CREATED \
-      org.opencontainers.image.version=$VERSION \
-      org.opencontainers.image.revision=$COMMIT
+    org.opencontainers.image.version=$VERSION \
+    org.opencontainers.image.revision=$COMMIT
 
 # Expose RPC port
 EXPOSE 57291

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 clap                      = { version = "4.5", features = ["derive"] }
 futures                   = { version = "0.3" }
 miden-air                 = { workspace = true }
-miden-block-prover        = { git = "https://github.com/0xMiden/miden-base.git", branch = "next", features = ["testing"] }
+miden-block-prover        = { version = "0.9", features = ["testing"] }
 miden-lib                 = { workspace = true }
 miden-node-block-producer = { workspace = true }
 miden-node-proto          = { workspace = true }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -18,28 +18,25 @@ workspace = true
 tracing-forest = ["miden-node-utils/tracing-forest"]
 
 [dependencies]
-anyhow = { workspace = true }
-futures = { version = "0.3" }
-itertools = { workspace = true }
-miden-block-prover = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
-miden-lib = { workspace = true }
-miden-node-proto = { workspace = true }
-miden-node-utils = { workspace = true, features = ["testing"] }
-miden-objects = { workspace = true }
-miden-processor = { workspace = true }
-miden-proving-service-client = { git = "https://github.com/0xMiden/miden-base.git", branch = "next", features = [
-  "batch-prover",
-  "block-prover",
-] }
-miden-tx-batch-prover = { git = "https://github.com/0xMiden/miden-base.git", branch = "next" }
-rand = { version = "0.9" }
-thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tokio-stream = { workspace = true, features = ["net"] }
-tonic = { workspace = true, features = ["transport"] }
-tower-http = { workspace = true, features = ["util"] }
-tracing = { workspace = true }
-url = { workspace = true }
+anyhow                       = { workspace = true }
+futures                      = { version = "0.3" }
+itertools                    = { workspace = true }
+miden-block-prover           = { version = "0.9" }
+miden-lib                    = { workspace = true }
+miden-node-proto             = { workspace = true }
+miden-node-utils             = { workspace = true, features = ["testing"] }
+miden-objects                = { workspace = true }
+miden-processor              = { workspace = true }
+miden-proving-service-client = { version = "0.9", features = ["batch-prover", "block-prover"] }
+miden-tx-batch-prover        = { version = "0.9" }
+rand                         = { version = "0.9" }
+thiserror                    = { workspace = true }
+tokio                        = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio-stream                 = { workspace = true, features = ["net"] }
+tonic                        = { workspace = true, features = ["transport"] }
+tower-http                   = { workspace = true, features = ["util"] }
+tracing                      = { workspace = true }
+url                          = { workspace = true }
 
 [dev-dependencies]
 assert_matches        = { workspace = true }


### PR DESCRIPTION
In preparation for the 0.9 release, this PR updates the versions of the miden crates, so that the latest stable released version is used. This is also needed so that we can also update the client's versions.