### PR TITLE
fix: ignore unexpected accept headers

### DIFF
--- a/crates/rpc/src/server/accept.rs
+++ b/crates/rpc/src/server/accept.rs
@@ -93,8 +93,10 @@ where
         let accept = match AcceptHeaderValue::try_from(accept_str) {
             Ok(value) => value,
             Err(e) => {
+                // If the accept header value is different from expected, don't enforce the version
+                // requirement.
                 debug!(target: COMPONENT, "Failed to parse accept header value: {}", e);
-                return bad_request("Invalid accept header value".into()).boxed();
+                return self.inner.call(request).boxed();
             },
         };
 


### PR DESCRIPTION
Seems like `tonic-web-wasm-client` uses a [different accept header](https://github.com/devashishdxt/tonic-web-wasm-client/blob/75762cbc8777d4c493648983e94f014e25e6af6b/src/call.rs#L44-L46) than what the node expects. This meant that all rpc requests failed because the header coulnd't be parsed.

This PR makes it so that the version requirement is ignored if the header doesn't have the expected format.

Note: We also saw some requests with `"*/*"` as the accept header but I couldn't find this in the tonic's code.