### PR TITLE
fix(ntx): Conversions and column rename

### DIFF
--- a/bin/node/src/commands/bundled.rs
+++ b/bin/node/src/commands/bundled.rs
@@ -207,7 +207,7 @@ impl BundledCommand {
                     ticker_interval_ms: 200u64,
                     account_cache_capacity: NonZeroUsize::new(128).expect("non-zero"),
                 }
-                .serve_resilient()
+                .serve_once()
                 .await
                 .context("failed while serving ntx builder component")
             })

--- a/crates/ntx-builder/src/builder/server/state.rs
+++ b/crates/ntx-builder/src/builder/server/state.rs
@@ -186,7 +186,7 @@ mod tests {
 
     use super::*;
 
-    /// Creates a note for a netwokr account with a 30-bit prefix based on the input.
+    /// Creates a note for a network account with a 30-bit prefix based on the input.
     fn mock_note(account_id_diff: u32) -> NetworkNote {
         let metadata = NoteMetadata::new(
             ACCOUNT_ID_PRIVATE_SENDER.try_into().unwrap(),

--- a/crates/ntx-builder/src/builder/server/state.rs
+++ b/crates/ntx-builder/src/builder/server/state.rs
@@ -105,10 +105,10 @@ impl PendingNotes {
                     .expect("note must be on the map if nullifier was found")
                     .metadata()
                     .tag();
-
-                let bucket =
-                    self.by_tag.get_mut(&tag).expect("any tracked note is in the by_tag map");
-                bucket.retain(|&x| x != id);
+                // The bucket may have been pruned already, so check before
+                if let Some(bucket) = self.by_tag.get_mut(&tag) {
+                    bucket.retain(|&x| x != id);
+                }
                 self.prune_map_if_empty(tag);
             }
         }
@@ -180,17 +180,24 @@ mod tests {
             Note, NoteAssets, NoteExecutionMode, NoteInputs, NoteMetadata, NoteRecipient,
             NoteScript,
         },
-        testing::account_id::ACCOUNT_ID_PRIVATE_SENDER,
+        testing::account_id::{ACCOUNT_ID_NETWORK_FUNGIBLE_FAUCET, ACCOUNT_ID_PRIVATE_SENDER},
     };
     use rand::{Rng, rng};
 
     use super::*;
 
-    fn mock_note(tag_suffix: u16) -> NetworkNote {
+    /// Creates a note for a netwokr account with a 30-bit prefix based on the input.
+    fn mock_note(account_id_diff: u32) -> NetworkNote {
         let metadata = NoteMetadata::new(
             ACCOUNT_ID_PRIVATE_SENDER.try_into().unwrap(),
             miden_objects::note::NoteType::Public,
-            NoteTag::for_public_use_case(0, tag_suffix, NoteExecutionMode::Network).unwrap(),
+            NoteTag::from_account_id(
+                (ACCOUNT_ID_NETWORK_FUNGIBLE_FAUCET + (u128::from(account_id_diff) << 99))
+                    .try_into()
+                    .unwrap(),
+                NoteExecutionMode::Network,
+            )
+            .unwrap(),
             miden_objects::note::NoteExecutionHint::Always,
             Felt::new(0),
         )

--- a/crates/proto/src/domain/note.rs
+++ b/crates/proto/src/domain/note.rs
@@ -137,9 +137,9 @@ impl TryFrom<Note> for NetworkNote {
         if !note.metadata().tag().is_single_target()
             || note.metadata().tag().execution_mode() != NoteExecutionMode::Network
         {
-            return Ok(NetworkNote(note));
+            return Err(NetworkNoteError::InvalidExecutionMode(note.metadata().tag()));
         }
-        Err(NetworkNoteError::InvalidExecutionMode(note.metadata().tag()))
+        Ok(NetworkNote(note))
     }
 }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -413,13 +413,16 @@ impl Db {
 
     /// Loads public account details from the DB based on the account ID's prefix.
     #[instrument(target = COMPONENT, skip_all, ret(level = "debug"), err)]
-    pub async fn select_account_by_prefix(&self, id_prefix: u32) -> Result<AccountInfo> {
+    pub async fn select_network_account_by_prefix(
+        &self,
+        id_prefix: u32,
+    ) -> Result<Option<AccountInfo>> {
         self.pool
             .get()
             .await?
             .interact(move |conn| {
                 let transaction = conn.transaction()?;
-                sql::select_account_by_prefix(&transaction, id_prefix)
+                sql::select_network_account_by_prefix(&transaction, id_prefix)
             })
             .await
             .map_err(|err| {

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -56,8 +56,6 @@ pub enum DatabaseError {
     },
     #[error("account {0} not found")]
     AccountNotFoundInDb(AccountId),
-    #[error("account with prefix {0:#010x} not found")]
-    AccountPrefixNotFound(u32),
     #[error("accounts {0:?} not found")]
     AccountsNotFoundInDb(Vec<AccountId>),
     #[error("account {0} is not on the chain")]

--- a/crates/store/src/server/api.rs
+++ b/crates/store/src/server/api.rs
@@ -342,18 +342,18 @@ impl api_server::Api for StoreApi {
         request: Request<GetNetworkAccountDetailsByPrefixRequest>,
     ) -> Result<Response<GetNetworkAccountDetailsByPrefixResponse>, Status> {
         let request = request.into_inner();
+
         // Validate that the call is for a valid network account prefix
         let prefix = NetworkAccountPrefix::try_from(request.account_id_prefix).map_err(|err| {
             Status::invalid_argument(format!(
                 "request does not contain a valid network account prefix: {err}"
             ))
         })?;
-
-        let account_info: AccountInfo =
-            self.state.get_account_details_by_prefix(prefix.inner()).await?;
+        let account_info: Option<AccountInfo> =
+            self.state.get_network_account_details_by_prefix(prefix.inner()).await?;
 
         Ok(Response::new(GetNetworkAccountDetailsByPrefixResponse {
-            details: Some((&account_info).into()),
+            details: account_info.map(|acc| (&acc).into()),
         }))
     }
 

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -820,7 +820,7 @@ impl State {
         self.db.select_account(id).await
     }
 
-    /// Returns details for public (on-chain) ntework accounts.
+    /// Returns details for public (on-chain) network accounts.
     pub async fn get_network_account_details_by_prefix(
         &self,
         id_prefix: u32,

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -820,12 +820,12 @@ impl State {
         self.db.select_account(id).await
     }
 
-    /// Returns details for public (on-chain) account.
-    pub async fn get_account_details_by_prefix(
+    /// Returns details for public (on-chain) ntework accounts.
+    pub async fn get_network_account_details_by_prefix(
         &self,
         id_prefix: u32,
-    ) -> Result<AccountInfo, DatabaseError> {
-        self.db.select_account_by_prefix(id_prefix).await
+    ) -> Result<Option<AccountInfo>, DatabaseError> {
+        self.db.select_network_account_by_prefix(id_prefix).await
     }
 
     /// Returns account proofs with optional account and storage headers.

--- a/proto/proto/responses.proto
+++ b/proto/proto/responses.proto
@@ -201,7 +201,7 @@ message GetAccountDetailsResponse {
 // Represents the result of getting network account details by prefix.
 message GetNetworkAccountDetailsByPrefixResponse {
     // Account info.
-    account.AccountInfo details = 1;
+    optional account.AccountInfo details = 1;
 }
 
 // Represents the result of getting block by number.


### PR DESCRIPTION
After [running a test](https://github.com/0xMiden/miden-client/pull/928/files#diff-593edd05ec1650928be20f1b680c82073de82143707903d4b76d31c4fa8e8e89R529), we found some issues related to the latest refactors in the NTB. This PR fixes them and adds minor refactors. I've also tested the builder by spamming with some notes for accounts that don't exist to see how it'd work and how the traces look.