### PR TITLE
Remove trailing `\` from usage.md

### DIFF
--- a/docs/src/operator/usage.md
+++ b/docs/src/operator/usage.md
@@ -35,7 +35,7 @@ mkdir accounts
 # implementation whose operation is described in a later section.
 miden-node bundled bootstrap \
   --data-directory data \
-  --accounts-directory accounts \
+  --accounts-directory accounts
 ```
 
 ## Operation


### PR DESCRIPTION
This was brought up in a different issue from an external contributor. I've run into this super minor detail a few times now as well, here's a PR to fix it. Feel free to close this PR if you think it should be batched into another more significant PR.

When copying:
```
miden-node bundled bootstrap \
  --data-directory data \
  --accounts-directory accounts \
```

The trailing `\` means the command is not executed.