### PR TITLE
chore: update dependencies to latest compatible versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ miden-proving-service-client = { version = "0.9" }
 miden-tx                     = { version = "0.9" }
 prost                        = { version = "0.13" }
 rand                         = { version = "0.9" }
-thiserror                    = { default-features = false, version = "2.0" }
-tokio                        = { features = ["rt-multi-thread"], version = "1.45" }
+thiserror                    = { default-features = false, version = "2.0.12" }
+tokio                        = { features = ["rt-multi-thread"], version = "1.45.1" }
 tokio-stream                 = { version = "0.1" }
 tonic                        = { version = "0.12" }
 tower                        = { version = "0.5" }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -48,7 +48,7 @@ miden-node-test-macro = { workspace = true }
 miden-node-utils      = { features = ["testing"], workspace = true }
 miden-objects         = { features = ["testing"], workspace = true }
 miden-tx              = { features = ["testing"], workspace = true }
-pretty_assertions     = "1.4"
+pretty_assertions     = "1.4.1"
 rand_chacha           = { default-features = false, version = "0.9" }
 serial_test           = "3.2"
 tempfile              = { version = "3.20" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -23,7 +23,7 @@ miden-node-utils = { workspace = true }
 miden-objects    = { workspace = true }
 miden-tx         = { workspace = true }
 nom              = { version = "8.0" }
-semver           = { version = "1.0" }
+semver           = { version = "1.0.26" }
 tokio            = { features = ["macros", "net", "rt-multi-thread"], workspace = true }
 tokio-stream     = { features = ["net"], workspace = true }
 tonic            = { workspace = true }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -16,14 +16,14 @@ workspace = true
 
 [dependencies]
 anyhow             = { workspace = true }
-deadpool           = { default-features = false, features = ["managed", "rt_tokio_1"], version = "0.12" }
+deadpool           = { default-features = false, features = ["managed", "rt_tokio_1"], version = "0.12.2" }
 deadpool-sync      = { version = "0.1" }
-hex                = { version = "0.4" }
+hex                = { version = "0.4.3" }
 miden-lib          = { workspace = true }
 miden-node-proto   = { workspace = true }
 miden-node-utils   = { workspace = true }
 miden-objects      = { workspace = true }
-rusqlite           = { features = ["array", "buildtime_bindgen", "bundled"], version = "0.35" }
+rusqlite           = { features = ["array", "bundled"], version = "0.35" }
 rusqlite_migration = { version = "2.1" }
 thiserror          = { workspace = true }
 tokio              = { features = ["fs", "macros", "net", "rt-multi-thread"], workspace = true }
@@ -40,4 +40,4 @@ miden-node-utils      = { features = ["tracing-forest"], workspace = true }
 miden-objects         = { features = ["testing"], workspace = true }
 rand                  = { version = "0.9" }
 regex                 = { version = "1.11" }
-termtree              = { version = "0.5" }
+termtree              = { version = "0.5.1" }


### PR DESCRIPTION
### Updated dependencies:
- **thiserror**: 2.0 → 2.0.12
- **tokio**: 1.45 → 1.45.1  
- **deadpool**: 0.12 → 0.12.2
- **hex**: 0.4 → 0.4.3
- **semver**: 1.0 → 1.0.26
- **pretty_assertions**: 1.4 → 1.4.1 (dev)
- **termtree**: 0.5 → 0.5.1 (dev)

### Compatibility constraints:
- **rusqlite**: kept at 0.35 (rusqlite_migration compatibility)
- **tonic-web**: kept at 0.12 (API compatibility)

Closes #883