### PR TITLE
chore: Bump genesis faucet supply to u32 max

### DIFF
--- a/bin/faucet/README.md
+++ b/bin/faucet/README.md
@@ -15,14 +15,14 @@ make docker-run-node
 make install-faucet
 ```
 
-3. [Optional] Create faucet account (skip this step if you want to use an account from the genesis). This will generate authentication keypair and generate and write public faucet account data with its keypair into the file specified in `output-path`: 
+3. [Optional] Create faucet account (skip this step if you want to use an account from the genesis). This will generate authentication keypair and generate and write public faucet account data with its keypair into the file specified in `output-path`:
 
 ```bash
 miden-faucet create-faucet-account \
   --output-path <path to faucet.mac> \
-  --token-symbol POL \
-  --decimals 9 \
-  --max-supply 1000000000
+  --token-symbol MIDEN \
+  --decimals 6 \
+  --max-supply 100000000000
 ```
 > [!TIP]
 > This account will not be created on chain yet, creation on chain will happen on the first minting transaction.

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -155,7 +155,7 @@ impl StoreCommand {
         let decimals = 6u8;
         let base_unit = 10u64.pow(u32::from(decimals));
         let max_supply = 100_000_000_000u64 * base_unit;
-        let max_supply = Felt::try_from(max_supply).expect("max supply is less than u64::MAX");
+        let max_supply = Felt::try_from(max_supply).expect("max supply is less than field modulus");
 
         // Create the faucet.
         let (mut account, account_seed) = create_basic_fungible_faucet(

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -155,8 +155,8 @@ impl StoreCommand {
             rng.random(),
             AccountIdAnchor::PRE_GENESIS,
             TokenSymbol::try_from("MIDEN").expect("MIDEN should be a valid token symbol"),
-            12,
-            Felt::from(u32::MAX),
+            6,
+            Felt::try_from(100_000_000_000u64).expect("1e11 is less than u64::MAX"),
             miden_objects::account::AccountStorageMode::Public,
             AuthScheme::RpoFalcon512 { pub_key: secret.public_key() },
         )?;

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -154,7 +154,7 @@ impl StoreCommand {
         let (mut account, account_seed) = create_basic_fungible_faucet(
             rng.random(),
             AccountIdAnchor::PRE_GENESIS,
-            TokenSymbol::try_from("POL").expect("POL should be a valid token symbol"),
+            TokenSymbol::try_from("MIDEN").expect("MIDEN should be a valid token symbol"),
             12,
             Felt::from(u32::MAX),
             miden_objects::account::AccountStorageMode::Public,

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -161,7 +161,7 @@ impl StoreCommand {
         let (mut account, account_seed) = create_basic_fungible_faucet(
             rng.random(),
             AccountIdAnchor::PRE_GENESIS,
-            TokenSymbol::try_from("MIDEN").expect("MIDEN should be a valid token symbol"),
+            TokenSymbol::try_from("MIDEN").expect("MIDEN is a valid token symbol"),
             decimals,
             max_supply,
             miden_objects::account::AccountStorageMode::Public,

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -151,12 +151,19 @@ impl StoreCommand {
         let mut rng = ChaCha20Rng::from_seed(rand::random());
         let secret = SecretKey::with_rng(&mut get_rpo_random_coin(&mut rng));
 
+        // Calculate the max supply of the token.
+        let decimals = 6u8;
+        let base_unit = 10u64.pow(u32::from(decimals));
+        let max_supply = 100_000_000_000u64 * base_unit;
+        let total_supply = Felt::try_from(max_supply).expect("total supply is less than u64::MAX");
+
+        // Create the faucet.
         let (mut account, account_seed) = create_basic_fungible_faucet(
             rng.random(),
             AccountIdAnchor::PRE_GENESIS,
             TokenSymbol::try_from("MIDEN").expect("MIDEN should be a valid token symbol"),
-            6,
-            Felt::try_from(100_000_000_000u64).expect("1e11 is less than u64::MAX"),
+            decimals,
+            total_supply,
             miden_objects::account::AccountStorageMode::Public,
             AuthScheme::RpoFalcon512 { pub_key: secret.public_key() },
         )?;

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -156,7 +156,7 @@ impl StoreCommand {
             AccountIdAnchor::PRE_GENESIS,
             TokenSymbol::try_from("POL").expect("POL should be a valid token symbol"),
             12,
-            Felt::from(1_000_000u32),
+            Felt::from(u32::MAX),
             miden_objects::account::AccountStorageMode::Public,
             AuthScheme::RpoFalcon512 { pub_key: secret.public_key() },
         )?;

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -147,7 +147,7 @@ impl StoreCommand {
         Store::bootstrap(genesis_state, data_directory)
     }
 
-    fn generate_genesis_account() -> anyhow::Result<AccountFile> {
+    pub fn generate_genesis_account() -> anyhow::Result<AccountFile> {
         let mut rng = ChaCha20Rng::from_seed(rand::random());
         let secret = SecretKey::with_rng(&mut get_rpo_random_coin(&mut rng));
 
@@ -176,5 +176,15 @@ impl StoreCommand {
             Some(account_seed),
             AuthSecretKey::RpoFalcon512(secret),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StoreCommand;
+
+    #[test]
+    fn test_generate_genesis_account_no_panic() {
+        let _account = StoreCommand::generate_genesis_account().unwrap();
     }
 }

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -155,7 +155,7 @@ impl StoreCommand {
         let decimals = 6u8;
         let base_unit = 10u64.pow(u32::from(decimals));
         let max_supply = 100_000_000_000u64 * base_unit;
-        let total_supply = Felt::try_from(max_supply).expect("total supply is less than u64::MAX");
+        let max_supply = Felt::try_from(max_supply).expect("max supply is less than u64::MAX");
 
         // Create the faucet.
         let (mut account, account_seed) = create_basic_fungible_faucet(
@@ -163,7 +163,7 @@ impl StoreCommand {
             AccountIdAnchor::PRE_GENESIS,
             TokenSymbol::try_from("MIDEN").expect("MIDEN should be a valid token symbol"),
             decimals,
-            total_supply,
+            max_supply,
             miden_objects::account::AccountStorageMode::Public,
             AuthScheme::RpoFalcon512 { pub_key: secret.public_key() },
         )?;

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -147,7 +147,7 @@ impl StoreCommand {
         Store::bootstrap(genesis_state, data_directory)
     }
 
-    pub fn generate_genesis_account() -> anyhow::Result<AccountFile> {
+    fn generate_genesis_account() -> anyhow::Result<AccountFile> {
         let mut rng = ChaCha20Rng::from_seed(rand::random());
         let secret = SecretKey::with_rng(&mut get_rpo_random_coin(&mut rng));
 
@@ -191,7 +191,7 @@ mod tests {
     use super::StoreCommand;
 
     #[test]
-    fn test_generate_genesis_account_no_panic() {
+    fn generate_genesis_account_no_panic() {
         let _account = StoreCommand::generate_genesis_account().unwrap();
     }
 }


### PR DESCRIPTION
### Context

The default token supply generated on genesis is 1e6. This can run out pretty quickly for the purposes of our testnet faucet, for example.

### Changes
- Update genesis faucet token decimals to 6 and supply to 1e11 * 1e6.
- Replace POL token symbol with MIDEN.