### PR TITLE
test: gRPC web support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,7 @@ dependencies = [
  "miden-objects",
  "miden-tx",
  "nom 8.0.0",
+ "reqwest",
  "semver 1.0.26",
  "tempfile",
  "tokio",

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -36,4 +36,5 @@ url              = { workspace = true }
 [dev-dependencies]
 miden-node-store = { workspace = true }
 miden-node-utils = { features = ["tracing-forest"], workspace = true }
+reqwest          = { version = "0.12" }
 tempfile         = { version = "3.20" }

--- a/crates/rpc/src/server/accept.rs
+++ b/crates/rpc/src/server/accept.rs
@@ -211,10 +211,10 @@ mod tests {
 
     #[test]
     fn valid_accept_header_is_parsed() {
-        let input = "application/vnd.miden.v1.0.0+grpc";
+        let input = "application/vnd.miden.1.0.0+grpc";
         let expected = AcceptHeaderValue {
             app_name: "miden",
-            version: "v1.0.0",
+            version: "1.0.0",
             response_type: "grpc",
         };
         assert_eq!(AcceptHeaderValue::try_from(input), Ok(expected));

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -91,10 +91,12 @@ mod tests {
             .unwrap();
         let headers = response.headers();
 
-        // If `tonic_web` is enabled, the CORS headers should be set in the response
+        // CORS headers are usually set when `tonic_web` is enabled.
+        //
+        // This was deduced by manually checking, and isn't formally described
+        // in any documentation.
         assert!(headers.get("access-control-allow-credentials").is_some());
         assert!(headers.get("access-control-expose-headers").is_some());
         assert!(headers.get("vary").is_some());
-        assert!(response.status().is_success());
     }
 }

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -80,7 +80,7 @@ mod tests {
 
         // An empty message with header format:
         //   - A byte indicating uncompressed (0)
-        //   - A u64 indicating the data length (0)
+        //   - A u32 indicating the data length (0)
         //
         // Originally described here:
         // https://github.com/hyperium/tonic/issues/1040#issuecomment-1191832200

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -78,9 +78,15 @@ mod tests {
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc-web+proto"));
         headers.insert(ACCEPT, HeaderValue::from_static(accept_header));
 
+        // An empty message with header format:
+        //   - A byte indicating uncompressed (0)
+        //   - A u64 indicating the data length (0)
+        //
+        // Originally described here:
+        // https://github.com/hyperium/tonic/issues/1040#issuecomment-1191832200
         let mut message = Vec::new();
-        message.push(0); // uncompressed flag
-        message.extend_from_slice(&[0; 4]); // length of empty message
+        message.push(0);
+        message.extend_from_slice(&0u64.to_be_bytes());
 
         let response = client
             .post(format!("http://{rpc_addr}/rpc.Api/Status"))

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -91,7 +91,7 @@ mod tests {
             .unwrap();
         let headers = response.headers();
 
-        // If `tonic_web` is enabled, the CORS headers shoud be set in the response
+        // If `tonic_web` is enabled, the CORS headers should be set in the response
         assert!(headers.get("access-control-allow-credentials").is_some());
         assert!(headers.get("access-control-expose-headers").is_some());
         assert!(headers.get("vary").is_some());

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -86,7 +86,7 @@ mod tests {
         // https://github.com/hyperium/tonic/issues/1040#issuecomment-1191832200
         let mut message = Vec::new();
         message.push(0);
-        message.extend_from_slice(&0u64.to_be_bytes());
+        message.extend_from_slice(&0u32.to_be_bytes());
 
         let response = client
             .post(format!("http://{rpc_addr}/rpc.Api/Status"))

--- a/docs/src/developer/rpc.md
+++ b/docs/src/developer/rpc.md
@@ -10,7 +10,7 @@ component), reducing the load in this critical component.
 
 ## RPC Versioning
 
-The RPC server enforces version requirements against connecting clients that povide the HTTP ACCEPT header. When this header is provided, its corresponding value must follow this format: `application/vnd.miden.v0.9.0+grpc`.
+The RPC server enforces version requirements against connecting clients that povide the HTTP ACCEPT header. When this header is provided, its corresponding value must follow this format: `application/vnd.miden.0.9.0+grpc`.
 
 If there is a mismatch in version, clients will encounter an error while executing gRPC requests against the RPC server with the following details:
 


### PR DESCRIPTION
closes https://github.com/0xMiden/miden-node/issues/788

This PR adds a test to ensure that the RPC server has enabled web support. The test makes a status request and checks that the response contains the CORS headers.

Additionally updated a doc and a test to show the correct version header format.