### PR TITLE
refactor: Valid nostd build for proving service client

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1950,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.1",
 ]
 
 [[package]]
@@ -2218,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-lib 0.10.0",
  "miden-objects 0.10.0",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2330,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-assembly",
  "miden-objects 0.10.0",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2773,7 +2773,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2809,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "async-trait",
  "miden-lib 0.10.0",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-objects 0.10.0",
  "miden-tx 0.10.0",
@@ -3125,7 +3125,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -5985,9 +5985,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "e2b85ac982d24496e0b49912479da8a89c0ba7b1d8bf6de49df12af42e94b325"
 dependencies = [
  "windows-collections",
  "windows-core",
@@ -6053,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "d3bfe459f85da17560875b8bf1423d6f113b7a87a5d942e7da0ac71be7c61f8b"
 
 [[package]]
 name = "windows-numerics"
@@ -6156,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "30357ec391cde730f8fbfcdc29adc47518b06504528df977ab5af02ef23fdee9"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,11 +2206,22 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d56092d4f95231029398f419e4844a029f5751515b28c57e2184e08e0fb84f"
+dependencies = [
+ "miden-lib 0.9.2",
+ "miden-objects 0.9.2",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "miden-block-prover"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
 dependencies = [
- "miden-lib",
- "miden-objects",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
  "thiserror 2.0.12",
 ]
 
@@ -2256,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "miden-faucet"
-version = "0.10.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2266,15 +2277,15 @@ dependencies = [
  "clap 4.5.40",
  "fantoccini",
  "http 1.3.1",
- "miden-lib",
+ "miden-lib 0.10.0",
  "miden-node-block-producer",
  "miden-node-proto",
  "miden-node-rpc",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "miden-proving-service-client",
- "miden-testing",
- "miden-tx",
+ "miden-testing 0.9.2",
+ "miden-tx 0.10.0",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "serde",
@@ -2304,11 +2315,25 @@ dependencies = [
 
 [[package]]
 name = "miden-lib"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c431f6de2408ccad6958c2d2a3f96399d67d05c5d783a692f5399910061452"
+dependencies = [
+ "miden-assembly",
+ "miden-objects 0.9.2",
+ "miden-stdlib",
+ "regex",
+ "thiserror 2.0.12",
+ "walkdir",
+]
+
+[[package]]
+name = "miden-lib"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
 dependencies = [
  "miden-assembly",
- "miden-objects",
+ "miden-objects 0.10.0",
  "miden-stdlib",
  "regex",
  "thiserror 2.0.12",
@@ -2364,13 +2389,13 @@ dependencies = [
  "anyhow",
  "clap 4.5.40",
  "figment",
- "miden-lib",
+ "miden-lib 0.10.0",
  "miden-node-block-producer",
  "miden-node-ntx-builder",
  "miden-node-rpc",
  "miden-node-store",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "sysinfo",
@@ -2388,16 +2413,16 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "miden-air",
- "miden-block-prover",
- "miden-lib",
+ "miden-block-prover 0.10.0",
+ "miden-lib 0.10.0",
  "miden-node-proto",
  "miden-node-proto-build",
  "miden-node-store",
  "miden-node-test-macro",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "miden-proving-service-client",
- "miden-tx",
+ "miden-tx 0.10.0",
  "miden-tx-batch-prover",
  "pretty_assertions",
  "rand 0.9.1",
@@ -2423,14 +2448,14 @@ dependencies = [
  "async-trait",
  "futures",
  "lru",
- "miden-lib",
+ "miden-lib 0.10.0",
  "miden-node-proto",
  "miden-node-proto-build",
  "miden-node-test-macro",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "miden-proving-service-client",
- "miden-tx",
+ "miden-tx 0.10.0",
  "rand 0.9.1",
  "thiserror 2.0.12",
  "tokio",
@@ -2451,7 +2476,7 @@ dependencies = [
  "http 1.3.1",
  "miden-node-proto-build",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "proptest",
  "prost",
  "prost-build",
@@ -2482,8 +2507,8 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-store",
  "miden-node-utils",
- "miden-objects",
- "miden-tx",
+ "miden-objects 0.10.0",
+ "miden-tx 0.10.0",
  "nom 8.0.0",
  "reqwest",
  "semver 1.0.26",
@@ -2508,12 +2533,12 @@ dependencies = [
  "deadpool",
  "deadpool-sync",
  "hex",
- "miden-lib",
+ "miden-lib 0.10.0",
  "miden-node-proto",
  "miden-node-proto-build",
  "miden-node-test-macro",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "rand 0.9.1",
  "regex",
  "rusqlite",
@@ -2535,13 +2560,13 @@ dependencies = [
  "clap 4.5.40",
  "futures",
  "miden-air",
- "miden-block-prover",
- "miden-lib",
+ "miden-block-prover 0.10.0",
+ "miden-lib 0.10.0",
  "miden-node-block-producer",
  "miden-node-proto",
  "miden-node-store",
  "miden-node-utils",
- "miden-objects",
+ "miden-objects 0.10.0",
  "rand 0.9.1",
  "rayon",
  "tokio",
@@ -2565,7 +2590,7 @@ dependencies = [
  "figment",
  "http 1.3.1",
  "itertools 0.14.0",
- "miden-objects",
+ "miden-objects 0.10.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2580,6 +2605,26 @@ dependencies = [
  "url",
  "vergen",
  "vergen-gitcl",
+]
+
+[[package]]
+name = "miden-objects"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c826da7048d600fba5794aa85c18366d7379604647f1f5d11ecebf68b5bd16c"
+dependencies = [
+ "bech32",
+ "getrandom 0.3.3",
+ "miden-assembly",
+ "miden-core",
+ "miden-crypto",
+ "miden-processor",
+ "miden-verifier",
+ "rand 0.9.1",
+ "rand_xoshiro",
+ "semver 1.0.26",
+ "thiserror 2.0.12",
+ "winter-rand-utils",
 ]
 
 [[package]]
@@ -2638,11 +2683,11 @@ dependencies = [
  "axum 0.8.4",
  "bytes",
  "clap 4.5.40",
- "miden-block-prover",
- "miden-lib",
- "miden-objects",
- "miden-testing",
- "miden-tx",
+ "miden-block-prover 0.10.0",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
+ "miden-testing 0.10.0",
+ "miden-tx 0.10.0",
  "miden-tx-batch-prover",
  "miette",
  "opentelemetry",
@@ -2681,8 +2726,8 @@ version = "0.10.0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
- "miden-objects",
- "miden-tx",
+ "miden-objects 0.10.0",
+ "miden-tx 0.10.0",
  "miette",
  "prost",
  "prost-build",
@@ -2707,17 +2752,37 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ef26ad08893456299e6b8e2f5efa553eff33ad9814370b8b3b5472cc3cc2d9"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "miden-block-prover 0.9.2",
+ "miden-crypto",
+ "miden-lib 0.9.2",
+ "miden-objects 0.9.2",
+ "miden-processor",
+ "miden-tx 0.9.2",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "winter-maybe-async",
+ "winterfell",
+]
+
+[[package]]
+name = "miden-testing"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
 dependencies = [
  "anyhow",
  "async-trait",
- "miden-block-prover",
+ "miden-block-prover 0.10.0",
  "miden-crypto",
- "miden-lib",
- "miden-objects",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
  "miden-processor",
- "miden-tx",
+ "miden-tx 0.10.0",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "winter-maybe-async",
@@ -2726,12 +2791,29 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df56744ebc643d505b027392e890a8b978f33e705c5f82d7b66363f3333526a5"
+dependencies = [
+ "async-trait",
+ "miden-lib 0.9.2",
+ "miden-objects 0.9.2",
+ "miden-processor",
+ "miden-prover",
+ "miden-verifier",
+ "rand 0.9.1",
+ "thiserror 2.0.12",
+ "winter-maybe-async",
+]
+
+[[package]]
+name = "miden-tx"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
 dependencies = [
  "async-trait",
- "miden-lib",
- "miden-objects",
+ "miden-lib 0.10.0",
+ "miden-objects 0.10.0",
  "miden-processor",
  "miden-prover",
  "miden-verifier",
@@ -2745,8 +2827,8 @@ name = "miden-tx-batch-prover"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#28897aa58cc601ec3c02a738047ac5a88c1a051b"
 dependencies = [
- "miden-objects",
- "miden-tx",
+ "miden-objects 0.10.0",
+ "miden-tx 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,22 +2206,11 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d56092d4f95231029398f419e4844a029f5751515b28c57e2184e08e0fb84f"
-dependencies = [
- "miden-lib 0.9.2",
- "miden-objects 0.9.2",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "miden-block-prover"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
- "miden-lib 0.10.0",
- "miden-objects 0.10.0",
+ "miden-lib",
+ "miden-objects",
  "thiserror 2.0.12",
 ]
 
@@ -2277,15 +2266,15 @@ dependencies = [
  "clap 4.5.40",
  "fantoccini",
  "http 1.3.1",
- "miden-lib 0.10.0",
+ "miden-lib",
  "miden-node-block-producer",
  "miden-node-proto",
  "miden-node-rpc",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "miden-proving-service-client",
- "miden-testing 0.9.2",
- "miden-tx 0.10.0",
+ "miden-testing",
+ "miden-tx",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "serde",
@@ -2315,25 +2304,11 @@ dependencies = [
 
 [[package]]
 name = "miden-lib"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c431f6de2408ccad6958c2d2a3f96399d67d05c5d783a692f5399910061452"
-dependencies = [
- "miden-assembly",
- "miden-objects 0.9.2",
- "miden-stdlib",
- "regex",
- "thiserror 2.0.12",
- "walkdir",
-]
-
-[[package]]
-name = "miden-lib"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "miden-assembly",
- "miden-objects 0.10.0",
+ "miden-objects",
  "miden-stdlib",
  "regex",
  "thiserror 2.0.12",
@@ -2389,13 +2364,13 @@ dependencies = [
  "anyhow",
  "clap 4.5.40",
  "figment",
- "miden-lib 0.10.0",
+ "miden-lib",
  "miden-node-block-producer",
  "miden-node-ntx-builder",
  "miden-node-rpc",
  "miden-node-store",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "sysinfo",
@@ -2413,16 +2388,16 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "miden-air",
- "miden-block-prover 0.10.0",
- "miden-lib 0.10.0",
+ "miden-block-prover",
+ "miden-lib",
  "miden-node-proto",
  "miden-node-proto-build",
  "miden-node-store",
  "miden-node-test-macro",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "miden-proving-service-client",
- "miden-tx 0.10.0",
+ "miden-tx",
  "miden-tx-batch-prover",
  "pretty_assertions",
  "rand 0.9.1",
@@ -2448,14 +2423,14 @@ dependencies = [
  "async-trait",
  "futures",
  "lru",
- "miden-lib 0.10.0",
+ "miden-lib",
  "miden-node-proto",
  "miden-node-proto-build",
  "miden-node-test-macro",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "miden-proving-service-client",
- "miden-tx 0.10.0",
+ "miden-tx",
  "rand 0.9.1",
  "thiserror 2.0.12",
  "tokio",
@@ -2476,7 +2451,7 @@ dependencies = [
  "http 1.3.1",
  "miden-node-proto-build",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "proptest",
  "prost",
  "prost-build",
@@ -2507,8 +2482,8 @@ dependencies = [
  "miden-node-proto-build",
  "miden-node-store",
  "miden-node-utils",
- "miden-objects 0.10.0",
- "miden-tx 0.10.0",
+ "miden-objects",
+ "miden-tx",
  "nom 8.0.0",
  "reqwest",
  "semver 1.0.26",
@@ -2533,12 +2508,12 @@ dependencies = [
  "deadpool",
  "deadpool-sync",
  "hex",
- "miden-lib 0.10.0",
+ "miden-lib",
  "miden-node-proto",
  "miden-node-proto-build",
  "miden-node-test-macro",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "rand 0.9.1",
  "regex",
  "rusqlite",
@@ -2560,13 +2535,13 @@ dependencies = [
  "clap 4.5.40",
  "futures",
  "miden-air",
- "miden-block-prover 0.10.0",
- "miden-lib 0.10.0",
+ "miden-block-prover",
+ "miden-lib",
  "miden-node-block-producer",
  "miden-node-proto",
  "miden-node-store",
  "miden-node-utils",
- "miden-objects 0.10.0",
+ "miden-objects",
  "rand 0.9.1",
  "rayon",
  "tokio",
@@ -2590,7 +2565,7 @@ dependencies = [
  "figment",
  "http 1.3.1",
  "itertools 0.14.0",
- "miden-objects 0.10.0",
+ "miden-objects",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2605,26 +2580,6 @@ dependencies = [
  "url",
  "vergen",
  "vergen-gitcl",
-]
-
-[[package]]
-name = "miden-objects"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c826da7048d600fba5794aa85c18366d7379604647f1f5d11ecebf68b5bd16c"
-dependencies = [
- "bech32",
- "getrandom 0.3.3",
- "miden-assembly",
- "miden-core",
- "miden-crypto",
- "miden-processor",
- "miden-verifier",
- "rand 0.9.1",
- "rand_xoshiro",
- "semver 1.0.26",
- "thiserror 2.0.12",
- "winter-rand-utils",
 ]
 
 [[package]]
@@ -2683,11 +2638,11 @@ dependencies = [
  "axum 0.8.4",
  "bytes",
  "clap 4.5.40",
- "miden-block-prover 0.10.0",
- "miden-lib 0.10.0",
- "miden-objects 0.10.0",
- "miden-testing 0.10.0",
- "miden-tx 0.10.0",
+ "miden-block-prover",
+ "miden-lib",
+ "miden-objects",
+ "miden-testing",
+ "miden-tx",
  "miden-tx-batch-prover",
  "miette",
  "opentelemetry",
@@ -2726,8 +2681,8 @@ version = "0.10.0"
 dependencies = [
  "async-trait",
  "getrandom 0.3.3",
- "miden-objects 0.10.0",
- "miden-tx 0.10.0",
+ "miden-objects",
+ "miden-tx",
  "miette",
  "prost",
  "prost-build",
@@ -2752,37 +2707,17 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ef26ad08893456299e6b8e2f5efa553eff33ad9814370b8b3b5472cc3cc2d9"
-dependencies = [
- "anyhow",
- "async-trait",
- "miden-block-prover 0.9.2",
- "miden-crypto",
- "miden-lib 0.9.2",
- "miden-objects 0.9.2",
- "miden-processor",
- "miden-tx 0.9.2",
- "rand 0.9.1",
- "rand_chacha 0.9.0",
- "winter-maybe-async",
- "winterfell",
-]
-
-[[package]]
-name = "miden-testing"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "anyhow",
  "async-trait",
- "miden-block-prover 0.10.0",
+ "miden-block-prover",
  "miden-crypto",
- "miden-lib 0.10.0",
- "miden-objects 0.10.0",
+ "miden-lib",
+ "miden-objects",
  "miden-processor",
- "miden-tx 0.10.0",
+ "miden-tx",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "winter-maybe-async",
@@ -2791,29 +2726,12 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df56744ebc643d505b027392e890a8b978f33e705c5f82d7b66363f3333526a5"
-dependencies = [
- "async-trait",
- "miden-lib 0.9.2",
- "miden-objects 0.9.2",
- "miden-processor",
- "miden-prover",
- "miden-verifier",
- "rand 0.9.1",
- "thiserror 2.0.12",
- "winter-maybe-async",
-]
-
-[[package]]
-name = "miden-tx"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
  "async-trait",
- "miden-lib 0.10.0",
- "miden-objects 0.10.0",
+ "miden-lib",
+ "miden-objects",
  "miden-processor",
  "miden-prover",
  "miden-verifier",
@@ -2827,8 +2745,8 @@ name = "miden-tx-batch-prover"
 version = "0.10.0"
 source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
 dependencies = [
- "miden-objects 0.10.0",
- "miden-tx 0.10.0",
+ "miden-objects",
+ "miden-tx",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,10 @@ miden-node-rpc               = { path = "crates/rpc", version = "0.10" }
 miden-node-store             = { path = "crates/store", version = "0.10" }
 miden-node-test-macro        = { path = "crates/test-macro" }
 miden-node-utils             = { path = "crates/utils", version = "0.10" }
-miden-objects                = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+miden-objects                = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
 miden-proving-service-client = { path = "crates/proving-service-client", version = "0.10" }
 miden-testing                = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
-miden-tx                     = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+miden-tx                     = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
 miden-tx-batch-prover        = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
 prost                        = { version = "0.13" }
 rand                         = { version = "0.9" }

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ check: ## Check all targets and features for errors without code generation
 build: ## Builds all crates and re-builds ptotobuf bindings for proto crates
 	${BUILD_PROTO} cargo build --locked --workspace --exclude miden-proving-service # miden-tx async feature on.
 	${BUILD_PROTO} cargo build --locked -p miden-proving-service  # miden-tx async feature off
+	${BUILD_PROTO} cargo build --locked -p miden-proving-service-client --target wasm32-unknown-unknown --no-default-features  # no-std compatible build
 
 # --- installing ----------------------------------------------------------------------------------
 

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-faucet"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version.workspace      = true
+version                = "0.9.0"
 
 [lints]
 workspace = true
@@ -26,9 +26,9 @@ miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-rpc               = { workspace = true }
 miden-node-utils             = { workspace = true }
-miden-objects                = { workspace = true }
+miden-objects                = { default-features = true, workspace = true }
 miden-proving-service-client = { features = ["tx-prover"], workspace = true }
-miden-tx                     = { features = ["async", "concurrent"], workspace = true }
+miden-tx                     = { default-features = true, features = ["async", "concurrent"], workspace = true }
 rand                         = { features = ["thread_rng"], workspace = true }
 rand_chacha                  = { version = "0.9" }
 serde                        = { features = ["derive"], version = "1.0" }
@@ -53,13 +53,12 @@ miden-node-utils = { features = ["vergen"], workspace = true }
 fantoccini                = { version = "0.21" }
 miden-node-block-producer = { features = ["testing"], workspace = true }
 miden-objects             = { features = ["testing"], workspace = true }
-miden-testing             = { features = ["async"], workspace = true }
+miden-testing             = { features = ["async"], version = "0.9.0" }
 serde_json                = { version = "1.0" }
 tokio                     = { features = ["process"], workspace = true }
 tokio-stream              = { features = ["net"], workspace = true }
 tonic-web                 = { version = "0.12" }
 
 # Required to avoid false positives in cargo-machete
-# This is due to the `winter-maybe-async` crate not working standalone.
 [package.metadata.cargo-machete]
 ignored = ["async-trait"]

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -53,7 +53,7 @@ miden-node-utils = { features = ["vergen"], workspace = true }
 fantoccini                = { version = "0.21" }
 miden-node-block-producer = { features = ["testing"], workspace = true }
 miden-objects             = { features = ["testing"], workspace = true }
-miden-testing             = { features = ["async"], version = "0.9.0" }
+miden-testing             = { features = ["async"], workspace = true }
 serde_json                = { version = "1.0" }
 tokio                     = { features = ["process"], workspace = true }
 tokio-stream              = { features = ["net"], workspace = true }

--- a/bin/faucet/Cargo.toml
+++ b/bin/faucet/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-faucet"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.9.0"
+version.workspace      = true
 
 [lints]
 workspace = true
@@ -26,9 +26,9 @@ miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-rpc               = { workspace = true }
 miden-node-utils             = { workspace = true }
-miden-objects                = { default-features = true, workspace = true }
+miden-objects                = { workspace = true }
 miden-proving-service-client = { features = ["tx-prover"], workspace = true }
-miden-tx                     = { default-features = true, features = ["async", "concurrent"], workspace = true }
+miden-tx                     = { features = ["async", "concurrent"], workspace = true }
 rand                         = { features = ["thread_rng"], workspace = true }
 rand_chacha                  = { version = "0.9" }
 serde                        = { features = ["derive"], version = "1.0" }
@@ -60,5 +60,6 @@ tokio-stream              = { features = ["net"], workspace = true }
 tonic-web                 = { version = "0.12" }
 
 # Required to avoid false positives in cargo-machete
+# This is due to the `winter-maybe-async` crate not working standalone.
 [package.metadata.cargo-machete]
 ignored = ["async-trait"]

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -48,7 +48,7 @@ miden-lib             = { features = ["testing"], workspace = true }
 miden-node-store      = { workspace = true }
 miden-node-test-macro = { workspace = true }
 miden-node-utils      = { features = ["testing"], workspace = true }
-miden-objects         = { features = ["testing"], workspace = true }
+miden-objects         = { default-features = true, features = ["testing"], workspace = true }
 miden-tx              = { features = ["testing"], workspace = true }
 pretty_assertions     = "1.4"
 rand_chacha           = { default-features = false, version = "0.9" }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -27,9 +27,9 @@ miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-proto-build       = { features = ["internal"], workspace = true }
 miden-node-utils             = { features = ["testing"], workspace = true }
-miden-objects                = { features = ["default"], workspace = true }
+miden-objects                = { default-features = true, workspace = true }
 miden-proving-service-client = { features = ["batch-prover", "block-prover"], workspace = true }
-miden-tx                     = { features = ["default"], workspace = true }
+miden-tx                     = { default-features = true, workspace = true }
 miden-tx-batch-prover        = { workspace = true }
 rand                         = { version = "0.9" }
 thiserror                    = { workspace = true }

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -27,9 +27,9 @@ miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-proto-build       = { features = ["internal"], workspace = true }
 miden-node-utils             = { features = ["testing"], workspace = true }
-miden-objects                = { workspace = true }
+miden-objects                = { features = ["default"], workspace = true }
 miden-proving-service-client = { features = ["batch-prover", "block-prover"], workspace = true }
-miden-tx                     = { workspace = true }
+miden-tx                     = { features = ["default"], workspace = true }
 miden-tx-batch-prover        = { workspace = true }
 rand                         = { version = "0.9" }
 thiserror                    = { workspace = true }

--- a/crates/ntx-builder/Cargo.toml
+++ b/crates/ntx-builder/Cargo.toml
@@ -22,9 +22,9 @@ miden-lib                    = { workspace = true }
 miden-node-proto             = { workspace = true }
 miden-node-proto-build       = { features = ["internal"], workspace = true }
 miden-node-utils             = { workspace = true }
-miden-objects                = { workspace = true }
+miden-objects                = { default-features = true, workspace = true }
 miden-proving-service-client = { features = ["tx-prover"], workspace = true }
-miden-tx                     = { workspace = true }
+miden-tx                     = { default-features = true, workspace = true }
 rand                         = { features = ["thread_rng"], workspace = true }
 thiserror                    = { workspace = true }
 tokio                        = { features = ["full"], workspace = true }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -21,8 +21,8 @@ http                   = { workspace = true }
 miden-node-proto       = { workspace = true }
 miden-node-proto-build = { workspace = true }
 miden-node-utils       = { workspace = true }
-miden-objects          = { workspace = true }
-miden-tx               = { workspace = true }
+miden-objects          = { default-features = true, workspace = true }
+miden-tx               = { default-features = true, workspace = true }
 nom                    = { version = "8.0" }
 semver                 = { version = "1.0" }
 tokio                  = { features = ["macros", "net", "rt-multi-thread"], workspace = true }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -23,7 +23,7 @@ miden-lib              = { workspace = true }
 miden-node-proto       = { workspace = true }
 miden-node-proto-build = { features = ["internal"], workspace = true }
 miden-node-utils       = { workspace = true }
-miden-objects          = { workspace = true }
+miden-objects          = { default-features = true, workspace = true }
 rusqlite               = { features = ["array", "buildtime_bindgen", "bundled"], version = "0.35" }
 rusqlite_migration     = { version = "2.1" }
 thiserror              = { workspace = true }
@@ -39,7 +39,7 @@ assert_matches        = { workspace = true }
 miden-lib             = { features = ["testing"], workspace = true }
 miden-node-test-macro = { workspace = true }
 miden-node-utils      = { features = ["tracing-forest"], workspace = true }
-miden-objects         = { features = ["testing"], workspace = true }
+miden-objects         = { default-features = true, features = ["testing"], workspace = true }
 rand                  = { version = "0.9" }
 regex                 = { version = "1.11" }
 termtree              = { version = "0.5" }


### PR DESCRIPTION
From the client, in order to make the proving service library available from `wasm32` targets, the repo was missing the configuration for `getrandom`. This PR adds it alongside a check that verifies whether the proving service client library can be built for web environments.

Additionally, because the proving service library crate relies on `miden-objects` and `miden-tx`, we need to make sure they dont' come with default features because these include `std` which makes the build fail.