### PR TITLE
ci: Add cache for Docker workflows

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,15 +28,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: GithubActionsSession
 
-      - name: Set cache key
-        id: cache-key
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "cache_key=miden-${{ matrix.component }}-pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "cache_key=miden-${{ matrix.component }}-main" >> $GITHUB_OUTPUT
-          fi
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -47,5 +38,5 @@ jobs:
         with:
           push: false
           file: ./bin/${{ matrix.component }}/Dockerfile
-          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }}
-          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }},mode=max
+          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}
+          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -47,5 +47,5 @@ jobs:
         with:
           push: false
           file: ./bin/${{ matrix.component }}/Dockerfile
-          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},${{ steps.cache-key.outputs.cache_key }}
-          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},${{ steps.cache-key.outputs.cache_key }},mode=max
+          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }}
+          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }},mode=max

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         component: [node, faucet]
     runs-on: ubuntu-latest
+    name: Build ${{ matrix.component }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: ${{ secerts.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: GithubActionsSession
 
@@ -31,9 +31,9 @@ jobs:
         id: cache-key
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "cache_key=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+            echo "cache_key=miden-${{ matrix.component }}-pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
           else
-            echo "cache_key=main" >> $GITHUB_OUTPUT
+            echo "cache_key=miden-${{ matrix.component }}-main" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Docker Buildx
@@ -46,5 +46,5 @@ jobs:
         with:
           push: false
           file: ./bin/${{ matrix.component }}/Dockerfile
-          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-node-${{ steps.cache-key.outputs.cache_key }}
-          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-node-${{ steps.cache-key.outputs.cache_key }},mode=max
+          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},${{ steps.cache-key.outputs.cache_key }}
+          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},${{ steps.cache-key.outputs.cache_key }},mode=max

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,6 +20,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: GithubActionsSession
+
+      - name: Set cache key
+        id: cache-key
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "cache_key=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "cache_key=main" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -30,5 +46,5 @@ jobs:
         with:
           push: false
           file: ./bin/${{ matrix.component }}/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-node-${{ steps.cache-key.outputs.cache_key }}
+          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-node-${{ steps.cache-key.outputs.cache_key }},mode=max

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           cache-binary: true
 
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
           push: false

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, next]
   pull_request:
     types: [opened, reopened, synchronize]
-    
+
 permissions:
   contents: read
 
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: true
 
       - name: Build Docker
         run: make docker-build-${{ matrix.component }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,5 +24,10 @@ jobs:
         with:
           cache-binary: true
 
-      - name: Build Docker
-        run: make docker-build-${{ matrix.component }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          file: ./bin/${{ matrix.component }}/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   docker-build:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secerts.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: GithubActionsSession
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -33,11 +33,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@main
         with:
-          ref: ${{ env.version}}
+          ref: ${{ env.version }}
           fetch-depth: 0
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -45,6 +42,11 @@ jobs:
           registry: ${{ env.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: true
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -48,10 +48,11 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
-          context: .
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           file: ./bin/${{ matrix.component }}/Dockerfile
           tags: ${{ env.registry }}/0xmiden/miden-${{ matrix.component }}:${{ env.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,4 +1,4 @@
-name: Publish Node and Faucet Debian Packages
+name: Publish Node and Faucet Docker Images
 
 on:
   release:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,6 +43,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: GithubActionsSession
+
+      - name: Set cache key
+        id: cache-key
+        run: |
+          echo "cache_key=miden-${{ matrix.component }}-main" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -56,5 +68,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: ./bin/${{ matrix.component }}/Dockerfile
           tags: ${{ env.registry }}/0xmiden/miden-${{ matrix.component }}:${{ env.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }}
+          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }},mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -50,11 +50,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: GithubActionsSession
 
-      - name: Set cache key
-        id: cache-key
-        run: |
-          echo "cache_key=miden-${{ matrix.component }}-main" >> $GITHUB_OUTPUT
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -68,5 +63,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: ./bin/${{ matrix.component }}/Dockerfile
           tags: ${{ env.registry }}/0xmiden/miden-${{ matrix.component }}:${{ env.version }}
-          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }}
-          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=${{ steps.cache-key.outputs.cache_key }},mode=max
+          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}
+          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }},mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   publish:
-    name: Publish ${{ inputs.version }} Docker
+    runs-on:
+      labels: "ubuntu-latest"
     strategy:
       matrix:
         component: [node, faucet]
-    runs-on:
-      labels: "ubuntu-latest"
+    name: Publish ${{ matrix.component }} ${{ inputs.version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@main


### PR DESCRIPTION
Closes #277

Triggered the on-release workflow manually to test: https://github.com/0xMiden/miden-node/actions/runs/15625025989/job/44017494929

Packages successfully published here: https://github.com/orgs/0xMiden/packages?repo_name=miden-node

Uses AWS S3 as cache backend for the Docker layers.