### PR TITLE
ci: Cache Docker only on non-forks

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,11 +22,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials
+        if: github.event.pull_request.head.repo.fork == false
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: GithubActionsSession
+
+      - name: Set cache parameters
+        if: github.event.pull_request.head.repo.fork == false
+        run: |
+          echo "CACHE_FROM=type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}" >> $GITHUB_ENV
+          echo "CACHE_TO=type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,5 +45,5 @@ jobs:
         with:
           push: false
           file: ./bin/${{ matrix.component }}/Dockerfile
-          cache-from: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}
-          cache-to: type=s3,region=${{ secrets.AWS_REGION }},bucket=${{ secrets.AWS_CACHE_BUCKET }},name=miden-${{ matrix.component }}
+          cache-from: ${{ env.CACHE_FROM || '' }}
+          cache-to: ${{ env.CACHE_TO || '' }}


### PR DESCRIPTION
## Context

PRs created by forks of this repo cannot use secrets until they are approved. This means that the docker build workflow will fail for those PRs because it requires access to the S3 backend for caching.

Verified the non-fork version did use cache here https://github.com/0xMiden/miden-node/pull/979.

## Changes

- Only use AWS S3 and Docker caching for the PR Docker build workflow when the PR is created from the main repository, not a fork