### PR TITLE
Remove duplicate ntx-builder entry in workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
   "bin/stress-test",
   "crates/block-producer",
   "crates/ntx-builder",
-  "crates/ntx-builder",
   "crates/proto",
   "crates/proving-service-client",
   "crates/rpc",


### PR DESCRIPTION
Fixed duplicate workspace member entry for ntx-builder that could lead to unpredictable cargo behavior during builds and publishing. Clean, simple fix to maintain workspace integrity.

<img width="492" alt="image" src="https://github.com/user-attachments/assets/d09e9438-0f25-419f-9a95-5f97e65e8002" />

