### PR TITLE
chore: upgrade protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -1046,7 +1057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1379,6 +1390,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2091,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f9878c75891951ac4e8dd42793a84c4d07e5aaf27a8c88bfc097b70cd2c1cd"
+checksum = "af5e74b13a68f17c5a52d10adbce489faba95d2bd43d4d48014e4af818f109f8"
 dependencies = [
  "miden-core",
  "thiserror 2.0.12",
@@ -2103,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e3d328e85faa193464dff6b51d9a6ede860a0a0b91858f2370931346d67c26"
+checksum = "7c69a8a783df2730abfc3ae93df4b0232a93e409388d1fd6778768b1567417ac"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -2122,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a60526a76e363d5d52faf3bdf8e3aa7f99782484"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2131,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f716ca140dd0e89f5c96527c3554be1f0289f2519c905ac83a48f8db899a8"
+checksum = "520ff9eb4a4d0c7ade20a8a381136f4183857e8539d640277a539d59672a3c95"
 dependencies = [
  "lock_api",
  "loom",
@@ -2220,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a60526a76e363d5d52faf3bdf8e3aa7f99782484"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2501,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a60526a76e363d5d52faf3bdf8e3aa7f99782484"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2521,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796a5c11589731286ca1cb761b13be13e69e4e0606a5469ce815491989402ea"
+checksum = "024c8118fbbd61dd58d764e9a714cad6c89d8b9b58bfaecfa0a30657f92b0fc9"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2535,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc4b989306ca1b8bdba364af72547c563419e77220f4cd244ed2bf3557d351"
+checksum = "78191a0107c16d78b6d687cb55f30ef7d465d40f1f83e0e7d4627bc320ec36e0"
 dependencies = [
  "miden-air",
  "miden-processor",
@@ -2614,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887189ccce4f9bbf15dfdaff0e6842fb138a7432a8f21adde756fac114b07184"
+checksum = "43354accdf4338358bad76503dd2e3b10e7902b416b667e91bf1866d4c93a89d"
 dependencies = [
  "miden-assembly",
  "miden-core",
@@ -2625,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a60526a76e363d5d52faf3bdf8e3aa7f99782484"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2644,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a60526a76e363d5d52faf3bdf8e3aa7f99782484"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2660,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#43232ab0492236648d57d0ebd1e43d2643792949"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a60526a76e363d5d52faf3bdf8e3aa7f99782484"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2668,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b6edc80bf70f276be1c001748c1edf10bea6273a57ee3694fd73d79050fc09"
+checksum = "2a0043e6fe42c3f349d333e85793d07e3984a05d28a73620b3ff76940cfa74f8"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -3295,7 +3309,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb4b85ca73955092e7e2a6654304f6ee7868d38792f442733a197cbb3ac5f75"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "blake2",
  "bytes",
@@ -3330,7 +3344,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2298292e2dbd156294bcc8dd2ec34507277c78bab31bfe3aecc1cab9b1f91dff"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "brotli",
  "bytes",
@@ -3420,7 +3434,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a719a8cb5558ca06bd6076c97b8905d500ea556da89e132ba53d4272844f95b9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -3452,7 +3466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f1c33f6ce9ca9b8e81190796f7d4d543d1ab2a310097d884ebe48ce5d33c4d"
 dependencies = [
  "arrayvec",
- "hashbrown 0.15.4",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -4152,7 +4166,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4165,7 +4179,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4733,7 +4747,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5719,7 +5733,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,15 +34,7 @@ version      = "0.10.0"
 opt-level = 2
 
 [workspace.dependencies]
-anyhow                       = { version = "1.0" }
-assert_matches               = { version = "1.5" }
-async-trait                  = { version = "0.1" }
-futures                      = { version = "0.3" }
-http                         = { version = "1.3" }
-itertools                    = { version = "0.14" }
-miden-air                    = { version = "0.15" }
-miden-block-prover           = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
-miden-lib                    = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+# Workspace crates.
 miden-node-block-producer    = { path = "crates/block-producer", version = "0.10" }
 miden-node-ntx-builder       = { path = "crates/ntx-builder", version = "0.10" }
 miden-node-proto             = { path = "crates/proto", version = "0.10" }
@@ -51,23 +43,38 @@ miden-node-rpc               = { path = "crates/rpc", version = "0.10" }
 miden-node-store             = { path = "crates/store", version = "0.10" }
 miden-node-test-macro        = { path = "crates/test-macro" }
 miden-node-utils             = { path = "crates/utils", version = "0.10" }
-miden-objects                = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
 miden-proving-service-client = { path = "crates/proving-service-client", version = "0.10" }
-miden-testing                = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
-miden-tx                     = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
-miden-tx-batch-prover        = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
-prost                        = { version = "0.13" }
-rand                         = { version = "0.9" }
-thiserror                    = { default-features = false, version = "2.0" }
-tokio                        = { features = ["rt-multi-thread"], version = "1.45" }
-tokio-stream                 = { version = "0.1" }
-tonic                        = { version = "0.13" }
-tonic-reflection             = { version = "0.13" }
-tower                        = { version = "0.5" }
-tower-http                   = { features = ["cors", "trace"], version = "0.6" }
-tracing                      = { version = "0.1" }
-tracing-subscriber           = { features = ["env-filter", "fmt", "json"], version = "0.3" }
-url                          = { features = ["serde"], version = "2.5" }
+
+# miden-base aka protocol dependencies. These should be updated in sync.
+miden-block-prover    = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+miden-lib             = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+miden-objects         = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
+miden-testing         = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+miden-tx              = { branch = "next", default-features = false, git = "https://github.com/0xMiden/miden-base" }
+miden-tx-batch-prover = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
+
+# Other miden dependencies. These should align with those expected by miden-base.
+miden-air = { version = "0.15" }
+
+# External dependencies
+anyhow             = { version = "1.0" }
+assert_matches     = { version = "1.5" }
+async-trait        = { version = "0.1" }
+futures            = { version = "0.3" }
+http               = { version = "1.3" }
+itertools          = { version = "0.14" }
+prost              = { version = "0.13" }
+rand               = { version = "0.9" }
+thiserror          = { default-features = false, version = "2.0" }
+tokio              = { features = ["rt-multi-thread"], version = "1.45" }
+tokio-stream       = { version = "0.1" }
+tonic              = { version = "0.13" }
+tonic-reflection   = { version = "0.13" }
+tower              = { version = "0.5" }
+tower-http         = { features = ["cors", "trace"], version = "0.6" }
+tracing            = { version = "0.1" }
+tracing-subscriber = { features = ["env-filter", "fmt", "json"], version = "0.3" }
+url                = { features = ["serde"], version = "2.5" }
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-trait                  = { version = "0.1" }
 futures                      = { version = "0.3" }
 http                         = { version = "1.3" }
 itertools                    = { version = "0.14" }
-miden-air                    = { version = "0.14" }
+miden-air                    = { version = "0.15" }
 miden-block-prover           = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
 miden-lib                    = { branch = "next", git = "https://github.com/0xMiden/miden-base" }
 miden-node-block-producer    = { path = "crates/block-producer", version = "0.10" }

--- a/bin/faucet/src/faucet/mod.rs
+++ b/bin/faucet/src/faucet/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, rc::Rc, sync::Arc};
+use std::{collections::VecDeque, sync::Arc};
 
 use anyhow::{Context, anyhow};
 use miden_lib::{
@@ -162,7 +162,7 @@ pub struct Faucet {
     // Previous faucet account states used to perform rollbacks if a desync is detected.
     prior_state: VecDeque<Account>,
     tx_prover: Arc<FaucetProver>,
-    tx_executor: Rc<TransactionExecutor>,
+    authenticator: BasicAuthenticator<StdRng>,
     account_interface: AccountInterface,
     decimals: u8,
 }
@@ -231,31 +231,28 @@ impl Faucet {
             genesis_chain_mmr,
         ));
 
-        let public_key = match &account_file.auth_secret_key {
-            AuthSecretKey::RpoFalcon512(secret) => secret.public_key(),
-        };
-
-        let authenticator = Arc::new(BasicAuthenticator::<StdRng>::new(&[(
-            public_key.into(),
-            account_file.auth_secret_key,
-        )]));
+        let keypairs = account_file
+            .auth_secret_keys
+            .into_iter()
+            .map(|key| match key {
+                AuthSecretKey::RpoFalcon512(ref falcon) => (falcon.public_key().into(), key),
+            })
+            .collect::<Vec<_>>();
+        let authenticator = BasicAuthenticator::<StdRng>::new(&keypairs);
 
         let tx_prover = match remote_tx_prover_url {
             Some(url) => Arc::new(FaucetProver::remote(url)),
             None => Arc::new(FaucetProver::local()),
         };
 
-        let tx_executor =
-            Rc::new(TransactionExecutor::new(data_store.clone(), Some(authenticator.clone())));
-
         Ok(Self {
             data_store,
             id,
             prior_state: VecDeque::new(),
             tx_prover,
-            tx_executor,
             account_interface,
             decimals: faucet.decimals(),
+            authenticator,
         })
     }
 
@@ -437,7 +434,9 @@ impl Faucet {
         &self,
         tx_args: TransactionArgs,
     ) -> MintResult<ExecutedTransaction> {
-        self.tx_executor
+        let executor =
+            TransactionExecutor::new(self.data_store.as_ref(), Some(&self.authenticator));
+        executor
             .execute_transaction(
                 self.id.inner(),
                 BlockNumber::GENESIS,
@@ -586,8 +585,11 @@ mod tests {
                 AuthScheme::RpoFalcon512 { pub_key: secret.public_key() },
             )
             .unwrap();
-            let account_file =
-                AccountFile::new(account, Some(account_seed), AuthSecretKey::RpoFalcon512(secret));
+            let account_file = AccountFile::new(
+                account,
+                Some(account_seed),
+                vec![AuthSecretKey::RpoFalcon512(secret)],
+            );
 
             Faucet::load(account_file, &mut rpc_client, None).await.unwrap()
         };

--- a/bin/faucet/src/main.rs
+++ b/bin/faucet/src/main.rs
@@ -202,8 +202,11 @@ async fn run_faucet_command(cli: Cli) -> anyhow::Result<()> {
             )
             .context("failed to create basic fungible faucet account")?;
 
-            let account_data =
-                AccountFile::new(account, Some(account_seed), AuthSecretKey::RpoFalcon512(secret));
+            let account_data = AccountFile::new(
+                account,
+                Some(account_seed),
+                vec![AuthSecretKey::RpoFalcon512(secret)],
+            );
 
             let output_path = current_dir.join(output_path);
             account_data.write(&output_path).with_context(|| {

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -180,7 +180,7 @@ impl StoreCommand {
         Ok(AccountFile::new(
             account,
             Some(account_seed),
-            AuthSecretKey::RpoFalcon512(secret),
+            vec![AuthSecretKey::RpoFalcon512(secret)],
         ))
     }
 }

--- a/crates/ntx-builder/src/builder/mod.rs
+++ b/crates/ntx-builder/src/builder/mod.rs
@@ -170,7 +170,7 @@ impl NetworkTransactionBuilder {
                 info!(target: COMPONENT, "Spawned NTB ticker (ticks every {} ms)", &ticker_interval.as_millis());
                 let store = StoreClient::new(&store_url);
                 let data_store = Arc::new(NtxBuilderDataStore::new(store).await?);
-                let tx_executor = TransactionExecutor::new(data_store.clone(), None);
+                let tx_executor = TransactionExecutor::new(data_store.as_ref(), None);
                 let tx_prover = NtbTransactionProver::from(prover_addr);
                 let block_prod = BlockProducerClient::new(block_addr);
 
@@ -223,7 +223,7 @@ impl NetworkTransactionBuilder {
     ///   logged and the transaction gets rolled back.
     async fn build_network_tx(
         api_state: &SharedPendingNotes,
-        tx_executor: &TransactionExecutor,
+        tx_executor: &TransactionExecutor<'_, '_>,
         data_store: &Arc<NtxBuilderDataStore>,
         tx_prover: &NtbTransactionProver,
         block_prod: &BlockProducerClient,
@@ -327,7 +327,7 @@ impl NetworkTransactionBuilder {
     #[instrument(target = COMPONENT, name = "ntx_builder.filter_consumable_notes", skip_all, err)]
     async fn filter_consumable_notes(
         data_store: &Arc<NtxBuilderDataStore>,
-        tx_executor: &TransactionExecutor,
+        tx_executor: &TransactionExecutor<'_, '_>,
         tx_request: &NetworkTransactionRequest,
     ) -> Result<NetworkTransactionRequest, NtxBuilderError> {
         let input_notes = InputNotes::new(
@@ -391,7 +391,7 @@ impl NetworkTransactionBuilder {
     /// Executes the transaction with the account described by the request.
     #[instrument(target = COMPONENT, name = "ntx_builder.execute_transaction", skip_all, err)]
     async fn execute_transaction(
-        tx_executor: &TransactionExecutor,
+        tx_executor: &TransactionExecutor<'_, '_>,
         tx_request: NetworkTransactionRequest,
     ) -> Result<ExecutedTransaction, NtxBuilderError> {
         let input_notes = InputNotes::new(


### PR DESCRIPTION
This PR upgrades `miden-base` dependencies to latest `next`.

Notably, this includes `TransactionExecutor` becoming a short-lived object as per https://github.com/0xMiden/miden-base/pull/1469 and the `AccountFile` containing multiple authentication keys.

This primarily affected the faucet's code. Like the faucet could now be refactored slightly but I think a larger redesign is on the horizon so I've ignored that insofar as possible :)

I've also re-organized `Cargo.toml` so that we distinguish between external, node, protocol and other miden dependencies. I've confirmed that the taplo linting/formatting of it works as expected.

I'm fairly sure the `AccountFile` change should be considered a breaking change, but I don't think its worth a changelog entry? Or rather, likely we should file this under general protocol upgrades closer to the release?