### PR TITLE
ci: Split debian steps into jobs

### DIFF
--- a/.github/workflows/publish-debian-all.yml
+++ b/.github/workflows/publish-debian-all.yml
@@ -19,8 +19,8 @@ permissions:
   contents: write
 
 jobs:
-  publish:
-    name: Publish Prover ${{ matrix.arch }} Debian
+  publish-node:
+    name: Publish Node ${{ matrix.arch }} Debian
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 0
-
       - name: Build and Publish Node
         uses: ./.github/actions/debian
         with:
@@ -43,6 +42,18 @@ jobs:
           crate: miden-node
           arch: ${{ matrix.arch }}
 
+  publish-faucet:
+    name: Publish Faucet ${{ matrix.arch }} Debian
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on:
+      labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
       - name: Build and Publish Faucet
         uses: ./.github/actions/debian
         with:
@@ -54,6 +65,18 @@ jobs:
           crate: miden-faucet
           arch: ${{ matrix.arch }}
 
+  publish-prover:
+    name: Publish Prover ${{ matrix.arch }} Debian
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on:
+      labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
       - name: Build and Publish Prover
         uses: ./.github/actions/debian
         with:
@@ -65,6 +88,18 @@ jobs:
           crate: miden-proving-service
           arch: ${{ matrix.arch }}
 
+  publish-prover-proxy:
+    name: Publish Prover Proxy ${{ matrix.arch }} Debian
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on:
+      labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
       - name: Build and Publish Prover Proxy
         uses: ./.github/actions/debian
         with:


### PR DESCRIPTION
## Context

We forgot to split the Debian publish steps into separate jobs. They are all serially executed because of this.

## Changes
- Move Debian publish steps into separate jobs for each service