### PR TITLE
fix(clippy): obfuscated if else

### DIFF
--- a/crates/block-producer/src/test_utils/account.rs
+++ b/crates/block-producer/src/test_utils/account.rs
@@ -50,7 +50,11 @@ impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
                 Digest::default(),
             )
             .unwrap(),
-            new_account.not().then(|| Hasher::hash(&init_seed)).unwrap_or_default(),
+            if new_account.not() {
+                Hasher::hash(&init_seed)
+            } else {
+                Digest::default()
+            },
         )
     }
 }

--- a/crates/block-producer/src/test_utils/account.rs
+++ b/crates/block-producer/src/test_utils/account.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Not, sync::LazyLock};
+use std::{collections::HashMap, sync::LazyLock};
 
 use miden_objects::{
     Digest, Hasher,
@@ -50,10 +50,10 @@ impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
                 Digest::default(),
             )
             .unwrap(),
-            if new_account.not() {
-                Hasher::hash(&init_seed)
-            } else {
+            if new_account {
                 Digest::default()
+            } else {
+                Hasher::hash(&init_seed)
             },
         )
     }


### PR DESCRIPTION
The [new version of Rust](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/) just came out. It includes a new lint rule: [obfuscated if else](https://rust-lang.github.io/rust-clippy/master/index.html#obfuscated_if_else). 