### PR TITLE
store: minor refactor to reduce boilerplate 

### DIFF
--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -6,7 +6,10 @@ use tracing::{debug, error, info, instrument};
 
 use crate::{
     COMPONENT,
-    db::{connection::Connection, settings::Settings, sql::utils::schema_version},
+    db::{
+        connection::Connection, settings::Settings, sql::utils::schema_version,
+        transaction::Transaction,
+    },
     errors::DatabaseError,
 };
 
@@ -24,7 +27,7 @@ const DB_MIGRATION_HASH_FIELD: &str = "db-migration-hash";
 const DB_SCHEMA_VERSION_FIELD: &str = "db-schema-version";
 
 #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
-pub fn apply_migrations(conn: &mut Connection) -> super::Result<()> {
+pub fn apply_migrations(conn: &mut Transaction<'_>) -> super::Result<()> {
     let version_before = MIGRATIONS.current_version(conn)?;
 
     info!(target: COMPONENT, %version_before, "Running database migrations");

--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -6,10 +6,7 @@ use tracing::{debug, error, info, instrument};
 
 use crate::{
     COMPONENT,
-    db::{
-        connection::Connection, settings::Settings, sql::utils::schema_version,
-        transaction::Transaction,
-    },
+    db::{connection::Connection, settings::Settings, sql::utils::schema_version},
     errors::DatabaseError,
 };
 
@@ -27,7 +24,7 @@ const DB_MIGRATION_HASH_FIELD: &str = "db-migration-hash";
 const DB_SCHEMA_VERSION_FIELD: &str = "db-schema-version";
 
 #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
-pub fn apply_migrations(conn: &mut Transaction<'_>) -> super::Result<()> {
+pub fn apply_migrations(conn: &mut Connection) -> super::Result<()> {
     let version_before = MIGRATIONS.current_version(conn)?;
 
     info!(target: COMPONENT, %version_before, "Running database migrations");

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -295,7 +295,7 @@ impl Db {
         E: From<rusqlite::Error>,
         E: std::error::Error + Send + Sync + 'static,
     {
-        let conn = self.pool.get().await.unwrap(); // FIXME XXX TOODO
+        let conn = self.pool.get().await.map_err(DatabaseError::MissingDbConnection)?;
 
         conn.interact(move |conn| {
             let r = query(conn)?;

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -9,7 +9,6 @@ use miden_node_proto::{
     domain::account::{AccountInfo, AccountSummary},
     generated::note as proto,
 };
-use miden_node_utils::ErrorReport;
 use miden_objects::{
     Word,
     account::{AccountDelta, AccountId},
@@ -28,8 +27,10 @@ use tracing::{info, info_span, instrument};
 use crate::{
     COMPONENT,
     db::{
+        connection::Connection,
         migrations::apply_migrations,
         pool_manager::{Pool, SqlitePoolManager},
+        transaction::Transaction,
     },
     errors::{DatabaseError, DatabaseSetupError, NoteSyncError, StateSyncError},
     genesis::GenesisBlock,
@@ -160,21 +161,16 @@ impl NoteRecord {
     }
 }
 
-impl From<NoteRecord> for proto::CommittedNote {
+impl From<NoteRecord> for proto::Note {
     fn from(note: NoteRecord) -> Self {
-        let inclusion_proof = Some(proto::NoteInclusionInBlockProof {
-            note_id: Some(note.note_id.into()),
+        Self {
             block_num: note.block_num.as_u32(),
-            note_index_in_block: note.note_index.leaf_index_value().into(),
-            merkle_path: Some(Into::into(&note.merkle_path)),
-        });
-
-        let note = Some(proto::Note {
+            note_index: note.note_index.leaf_index_value().into(),
+            note_id: Some(note.note_id.into()),
             metadata: Some(note.metadata.into()),
-            details: note.details.map(|details| details.to_bytes()),
-        });
-
-        Self { inclusion_proof, note }
+            merkle_path: Some(Into::into(&note.merkle_path)),
+            details: note.details.as_ref().map(Serializable::to_bytes),
+        }
     }
 }
 
@@ -260,6 +256,30 @@ impl Db {
         db_tx.commit().context("failed to commit database transaction")
     }
 
+    /// Avoid repeated boilerplate, frame the query in a transaction
+    pub(crate) async fn framed<R, E, Q, M>(&self, msg: M, query: Q) -> std::result::Result<R, E>
+    where
+        Q: Send
+            + for<'a, 't> FnOnce(&'a mut Transaction<'t>) -> std::result::Result<R, E>
+            + 'static,
+        R: Send + 'static,
+        M: Send + ToString,
+        E: From<DatabaseError>,
+        E: From<rusqlite::Error>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let conn = self.pool.get().await.unwrap(); // FIXME XXX TOODO
+
+        conn.interact(|conn| {
+            let mut db_tx = conn.transaction()?;
+            let r = query(&mut db_tx)?;
+            db_tx.commit()?;
+            Ok(r)
+        })
+        .await
+        .map_err(|err| E::from(DatabaseError::interact(&msg.to_string(), &err)))?
+    }
+
     /// Open a connection to the DB and apply any pending migrations.
     #[instrument(target = COMPONENT, skip_all)]
     pub async fn load(database_filepath: PathBuf) -> Result<Self, DatabaseSetupError> {
@@ -272,29 +292,21 @@ impl Db {
             "Connected to the database"
         );
 
-        let conn = pool.get().await.map_err(DatabaseError::MissingDbConnection)?;
+        let me = Db { pool };
+        me.framed("migration", |conn| apply_migrations(conn)).await?;
 
-        conn.interact(apply_migrations).await.map_err(|err| {
-            DatabaseError::InteractError(err.as_report_context("migration task failed"))
-        })??;
-
-        Ok(Db { pool })
+        // TODO rationalize magic numbers, and make them
+        Ok(me)
     }
 
     /// Loads all the nullifiers from the DB.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
-    pub async fn select_all_nullifiers(&self) -> Result<Vec<(Nullifier, BlockNumber)>> {
-        self.pool
-            .get()
-            .await?
-            .interact(|conn| {
-                let transaction = conn.transaction()?;
-                sql::select_all_nullifiers(&transaction)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(err.as_report_context("select nullifiers task failed"))
-            })?
+    pub async fn select_all_nullifiers(&self) -> Result<Vec<NullifierInfo>> {
+        self.framed("all nullifiers", move |conn| {
+            let nullifiers = sql::select_all_nullifiers(conn)?;
+            Ok(nullifiers)
+        })
+        .await
     }
 
     /// Loads the nullifiers that match the prefixes from the DB.
@@ -305,24 +317,17 @@ impl Db {
         nullifier_prefixes: Vec<u32>,
         block_num: BlockNumber,
     ) -> Result<Vec<NullifierInfo>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_nullifiers_by_prefix(
-                    &transaction,
-                    prefix_len,
-                    &nullifier_prefixes,
-                    block_num,
-                )
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("select nullifiers by prefix task failed"),
-                )
-            })?
+        assert_eq!(prefix_len, 16, "Only 16-bit prefixes are supported");
+
+        self.framed("nullifieres by prefix", move |conn| {
+            sql::select_nullifiers_by_prefix(
+                conn,
+                prefix_len as u32,
+                &nullifier_prefixes[..],
+                block_num,
+            )
+        })
+        .await
     }
 
     /// Search for a [BlockHeader] from the database by its `block_num`.
@@ -331,21 +336,13 @@ impl Db {
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_block_header_by_block_num(
         &self,
-        block_number: Option<BlockNumber>,
+        maybe_block_number: Option<BlockNumber>,
     ) -> Result<Option<BlockHeader>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_block_header_by_block_num(&transaction, block_number)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("select block header task failed"),
-                )
-            })?
+        self.framed("block headers by block number", move |conn| {
+            let val = sql::select_block_header_by_block_num(conn, maybe_block_number)?;
+            Ok(val)
+        })
+        .await
     }
 
     /// Loads multiple block headers from the DB.
@@ -354,73 +351,35 @@ impl Db {
         &self,
         blocks: impl Iterator<Item = BlockNumber> + Send + 'static,
     ) -> Result<Vec<BlockHeader>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_block_headers(&transaction, blocks)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("Select many block headers task failed"),
-                )
-            })?
+        self.framed("block headers from given block numbers", move |conn| {
+            let raw = sql::select_block_headers(conn, blocks)?;
+            Ok(raw)
+        })
+        .await
     }
 
     /// Loads all the block headers from the DB.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_block_headers(&self) -> Result<Vec<BlockHeader>> {
-        self.pool
-            .get()
-            .await?
-            .interact(|conn| {
-                let transaction = conn.transaction()?;
-                sql::select_all_block_headers(&transaction)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("select block headers task failed"),
-                )
-            })?
+        self.framed("all block headers", |conn| {
+            let raw = sql::select_all_block_headers(conn)?;
+            Ok(raw)
+        })
+        .await
     }
 
     /// Loads all the account commitments from the DB.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_all_account_commitments(&self) -> Result<Vec<(AccountId, RpoDigest)>> {
-        self.pool
-            .get()
-            .await?
-            .interact(|conn| {
-                let transaction = conn.transaction()?;
-                sql::select_all_account_commitments(&transaction)
-            })
+        self.framed("read all account commitments", sql::select_all_account_commitments)
             .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("select account commitments task failed"),
-                )
-            })?
     }
 
     /// Loads public account details from the DB.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_account(&self, id: AccountId) -> Result<AccountInfo> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_account(&transaction, id)
-            })
+        self.framed("Get account details", move |conn| sql::select_account(conn, id))
             .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("get account details task failed"),
-                )
-            })?
     }
 
     /// Loads public account details from the DB based on the account ID's prefix.
@@ -429,19 +388,10 @@ impl Db {
         &self,
         id_prefix: u32,
     ) -> Result<Option<AccountInfo>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_network_account_by_prefix(&transaction, id_prefix)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("get account details task failed"),
-                )
-            })?
+        self.framed("Get account by id prefix", move |conn| {
+            sql::select_network_account_by_prefix(conn, id_prefix)
+        })
+        .await
     }
 
     /// Loads public accounts details from the DB.
@@ -450,40 +400,23 @@ impl Db {
         &self,
         account_ids: Vec<AccountId>,
     ) -> Result<Vec<AccountInfo>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_accounts_by_ids(&transaction, &account_ids)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("get accounts details task failed"),
-                )
-            })?
+        self.framed("Select account by id set", move |conn| {
+            sql::select_accounts_by_ids(conn, &account_ids[..])
+        })
+        .await
     }
 
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn get_state_sync(
         &self,
-        block_num: BlockNumber,
+        block_number: BlockNumber,
         account_ids: Vec<AccountId>,
         note_tags: Vec<u32>,
     ) -> Result<StateSyncUpdate, StateSyncError> {
-        self.pool
-            .get()
-            .await
-            .map_err(DatabaseError::MissingDbConnection)?
-            .interact(move |conn| {
-                let transaction = conn.transaction().map_err(DatabaseError::SqliteError)?;
-                sql::get_state_sync(&transaction, block_num, &account_ids, &note_tags)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(err.as_report_context("get state sync task failed"))
-            })?
+        self.framed::<StateSyncUpdate, StateSyncError, _, _>("state sync", move |conn| {
+            sql::get_state_sync(conn, block_number, account_ids, note_tags)
+        })
+        .await
     }
 
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
@@ -492,34 +425,17 @@ impl Db {
         block_num: BlockNumber,
         note_tags: Vec<u32>,
     ) -> Result<NoteSyncUpdate, NoteSyncError> {
-        self.pool
-            .get()
-            .await
-            .map_err(DatabaseError::MissingDbConnection)?
-            .interact(move |conn| {
-                let transaction = conn.transaction().map_err(DatabaseError::SqliteError)?;
-                sql::get_note_sync(&transaction, block_num, &note_tags)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(err.as_report_context("get notes sync task failed"))
-            })?
+        self.framed("notes sync task", move |conn| {
+            sql::get_note_sync(conn, block_num, note_tags.as_slice())
+        })
+        .await
     }
 
     /// Loads all the Note's matching a certain NoteId from the database.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_notes_by_id(&self, note_ids: Vec<NoteId>) -> Result<Vec<NoteRecord>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_notes_by_id(&transaction, &note_ids)
-            })
+        self.framed("note by id", move |conn| sql::select_notes_by_id(conn, note_ids.as_slice()))
             .await
-            .map_err(|err| {
-                DatabaseError::InteractError(err.as_report_context("select note by id task failed"))
-            })?
     }
 
     /// Loads inclusion proofs for notes matching the given IDs.
@@ -528,19 +444,10 @@ impl Db {
         &self,
         note_ids: BTreeSet<NoteId>,
     ) -> Result<BTreeMap<NoteId, NoteInclusionProof>> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_note_inclusion_proofs(&transaction, note_ids)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("select block note inclusion proofs task failed"),
-                )
-            })?
+        self.framed("block note inclusion proofs", move |conn| {
+            sql::select_note_inclusion_proofs(conn, note_ids)
+        })
+        .await
     }
 
     /// Loads all note IDs matching a certain NoteId from the database.
@@ -564,36 +471,28 @@ impl Db {
         block: ProvenBlock,
         notes: Vec<(NoteRecord, Option<Nullifier>)>,
     ) -> Result<()> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| -> Result<()> {
-                // TODO: This span is logged in a root span, we should connect it to the parent one.
-                let _span = info_span!(target: COMPONENT, "write_block_to_db").entered();
+        self.framed("apply block", move |conn| -> Result<()> {
+            // TODO: This span is logged in a root span, we should connect it to the parent one.
+            let _span = info_span!(target: COMPONENT, "write_block_to_db").entered();
 
-                let transaction = conn.transaction()?;
-                sql::apply_block(
-                    &transaction,
-                    block.header(),
-                    &notes,
-                    block.created_nullifiers(),
-                    block.updated_accounts(),
-                    block.transactions(),
-                )?;
+            sql::apply_block(
+                conn,
+                block.header(),
+                &notes,
+                block.created_nullifiers(),
+                block.updated_accounts(),
+                block.transactions(),
+            )?;
 
-                let _ = allow_acquire.send(());
-                acquire_done.blocking_recv()?;
+            // XXX FIXME TODO free floating mutex MUST NOT exist
+            // it doesn't bind it properly to the data locked!
+            let _ = allow_acquire.send(());
 
-                transaction.commit()?;
+            acquire_done.blocking_recv()?;
 
-                Ok(())
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(err.as_report_context("apply block task failed"))
-            })??;
-
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
     /// Merges all account deltas from the DB for given account ID and block range.
@@ -607,35 +506,17 @@ impl Db {
         from_block: BlockNumber,
         to_block: BlockNumber,
     ) -> Result<Option<AccountDelta>> {
-        self.pool
-            .get()
-            .await
-            .map_err(DatabaseError::MissingDbConnection)?
-            .interact(move |conn| {
-                let transaction = conn.transaction()?;
-                sql::select_account_delta(&transaction, account_id, from_block, to_block)
-            })
-            .await
-            .map_err(|err| DatabaseError::InteractError(err.as_report()))?
+        self.framed("select account state data", move |conn| {
+            sql::select_account_delta(conn, account_id, from_block, to_block)
+        })
+        .await
     }
 
     /// Runs database optimization.
     #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn optimize(&self) -> Result<(), DatabaseError> {
-        self.pool
-            .get()
-            .await?
-            .interact(move |conn| -> Result<()> {
-                conn.execute("PRAGMA optimize;", ())
-                    .map(|_| ())
-                    .map_err(DatabaseError::SqliteError)
-            })
-            .await
-            .map_err(|err| {
-                DatabaseError::InteractError(
-                    err.as_report_context("database optimization task failed"),
-                )
-            })?
+        self.framed("db optimization", |conn| todo!("PRAGMA OPTIMIZE")).await?;
+        Ok(())
     }
 
     /// Loads the network notes that have not been consumed yet, using pagination to limit the
@@ -644,12 +525,9 @@ impl Db {
         &self,
         page: Page,
     ) -> Result<(Vec<NoteRecord>, Page)> {
-        self.pool
-            .get()
-            .await
-            .map_err(DatabaseError::MissingDbConnection)?
-            .interact(move |conn| sql::unconsumed_network_notes(&conn.transaction()?, page))
-            .await
-            .map_err(|err| DatabaseError::InteractError(err.as_report()))?
+        self.framed("unconsumed network notes", move |conn| {
+            sql::unconsumed_network_notes(conn, page)
+        })
+        .await
     }
 }

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -167,16 +167,19 @@ impl NoteRecord {
     }
 }
 
-impl From<NoteRecord> for proto::Note {
+impl From<NoteRecord> for proto::CommittedNote {
     fn from(note: NoteRecord) -> Self {
-        Self {
-            block_num: note.block_num.as_u32(),
-            note_index: note.note_index.leaf_index_value().into(),
+        let inclusion_proof = Some(proto::NoteInclusionInBlockProof {
             note_id: Some(note.note_id.into()),
-            metadata: Some(note.metadata.into()),
+            block_num: note.block_num.as_u32(),
+            note_index_in_block: note.note_index.leaf_index_value().into(),
             merkle_path: Some(Into::into(&note.merkle_path)),
-            details: note.details.as_ref().map(Serializable::to_bytes),
-        }
+        });
+        let note = Some(proto::Note {
+            metadata: Some(note.metadata.into()),
+            details: note.details.map(|details| details.to_bytes()),
+        });
+        Self { inclusion_proof, note }
     }
 }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -349,12 +349,7 @@ impl Db {
         assert_eq!(prefix_len, 16, "Only 16-bit prefixes are supported");
 
         self.framed("nullifieres by prefix", move |conn| {
-            sql::select_nullifiers_by_prefix(
-                conn,
-                prefix_len as u32,
-                &nullifier_prefixes[..],
-                block_num,
-            )
+            sql::select_nullifiers_by_prefix(conn, prefix_len, &nullifier_prefixes[..], block_num)
         })
         .await
     }

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -687,7 +687,7 @@ pub fn insert_nullifiers_for_block(
 /// # Returns
 ///
 /// A vector with nullifiers and the block height at which they were created, or an error.
-pub fn select_all_nullifiers(transaction: &Transaction) -> Result<Vec<(Nullifier, BlockNumber)>> {
+pub fn select_all_nullifiers(transaction: &Transaction) -> Result<Vec<NullifierInfo>> {
     let mut stmt = transaction
         .prepare_cached("SELECT nullifier, block_num FROM nullifiers ORDER BY block_num ASC")?;
     let mut rows = stmt.query([])?;
@@ -696,8 +696,8 @@ pub fn select_all_nullifiers(transaction: &Transaction) -> Result<Vec<(Nullifier
     while let Some(row) = rows.next()? {
         let nullifier_data = row.get_ref(0)?.as_blob()?;
         let nullifier = Nullifier::read_from_bytes(nullifier_data)?;
-        let block_number = read_block_number(row, 1)?;
-        result.push((nullifier, block_number));
+        let block_num = read_block_number(row, 1)?;
+        result.push(NullifierInfo { nullifier, block_num });
     }
     Ok(result)
 }

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use deadpool::managed::PoolError;
+use deadpool_sync::InteractError;
 use miden_node_proto::domain::account::NetworkAccountError;
 use miden_node_utils::limiter::QueryLimitError;
 use miden_objects::{

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -980,8 +980,10 @@ async fn load_nullifier_tree(db: &mut Db) -> Result<NullifierTree, StateInitiali
     let len = nullifiers.len();
 
     let now = Instant::now();
-    let nullifier_tree = NullifierTree::with_entries(nullifiers)
-        .map_err(StateInitializationError::FailedToCreateNullifierTree)?;
+    let nullifier_tree = NullifierTree::with_entries(
+        nullifiers.into_iter().map(|info| (info.nullifier, info.block_num)),
+    )
+    .map_err(StateInitializationError::FailedToCreateNullifierTree)?;
     let elapsed = now.elapsed().as_secs();
 
     info!(

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -170,8 +170,13 @@ impl State {
             .await?
             .ok_or(ApplyBlockError::DbBlockHeaderEmpty)?;
 
-        if block_num != prev_block.block_num() + 1 {
-            return Err(InvalidBlockError::NewBlockInvalidBlockNum.into());
+        let expected_block_num = prev_block.block_num() + 1;
+        if block_num != expected_block_num {
+            return Err(InvalidBlockError::NewBlockInvalidBlockNum {
+                expected: expected_block_num,
+                submitted: block_num,
+            }
+            .into());
         }
         if header.prev_block_commitment() != prev_block.commitment() {
             return Err(InvalidBlockError::NewBlockInvalidPrevCommitment.into());

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -170,7 +170,7 @@ impl State {
             .await?
             .ok_or(ApplyBlockError::DbBlockHeaderEmpty)?;
 
-        let expected_block_num = prev_block.block_num() + 1;
+        let expected_block_num = prev_block.block_num().child();
         if block_num != expected_block_num {
             return Err(InvalidBlockError::NewBlockInvalidBlockNum {
                 expected: expected_block_num,


### PR DESCRIPTION
Carve out from #928 

Introduces two intermediate functions `framed` and `framed_without_transaction`, which take a closure each, to either operate on a `&mut Transaction<'_>` or `&mut Connection` respectively. It puts all error handling of the sync/async boundary into those functions rather than have it at each wrapping of a `sql::*` function.

Also uses `NullifierInfo` more, rather than using `(Nullifier, Blocknumber)`, but does NOT expose it to the user in this PR, yet!