### PR TITLE
feat: add limits for queries

### DIFF
--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -29,6 +29,10 @@ use crate::{
     db::{
         migrations::apply_migrations,
         pool_manager::{Pool, SqlitePoolManager},
+        sql::utils::{
+            QueryParamAccountIdLimit, QueryParamLimiter, QueryParamNoteIdLimit,
+            QueryParamNoteTagLimit,
+        },
     },
     errors::{DatabaseError, DatabaseSetupError, NoteSyncError, StateSyncError},
     genesis::GenesisBlock,
@@ -456,6 +460,9 @@ impl Db {
         account_ids: Vec<AccountId>,
         note_tags: Vec<u32>,
     ) -> Result<StateSyncUpdate, StateSyncError> {
+        QueryParamAccountIdLimit::check(account_ids.len())?;
+        QueryParamNoteTagLimit::check(note_tags.len())?;
+
         self.pool
             .get()
             .await
@@ -476,6 +483,8 @@ impl Db {
         block_num: BlockNumber,
         note_tags: Vec<u32>,
     ) -> Result<NoteSyncUpdate, NoteSyncError> {
+        QueryParamNoteTagLimit::check(note_tags.len())?;
+
         self.pool
             .get()
             .await
@@ -493,6 +502,8 @@ impl Db {
     /// Loads all the Note's matching a certain NoteId from the database.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_notes_by_id(&self, note_ids: Vec<NoteId>) -> Result<Vec<NoteRecord>> {
+        QueryParamNoteIdLimit::check(note_ids.len())?;
+
         self.pool
             .get()
             .await?
@@ -512,6 +523,8 @@ impl Db {
         &self,
         note_ids: BTreeSet<NoteId>,
     ) -> Result<BTreeMap<NoteId, NoteInclusionProof>> {
+        QueryParamNoteIdLimit::check(note_ids.len())?;
+
         self.pool
             .get()
             .await?
@@ -530,6 +543,7 @@ impl Db {
     /// Loads all note IDs matching a certain NoteId from the database.
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
     pub async fn select_note_ids(&self, note_ids: Vec<NoteId>) -> Result<BTreeSet<NoteId>> {
+        QueryParamNoteIdLimit::check(note_ids.len())?;
         self.select_notes_by_id(note_ids)
             .await
             .map(|notes| notes.into_iter().map(|note| note.note_id.into()).collect())

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -35,6 +35,8 @@ use super::{
 use crate::{
     db::{
         sql::utils::{
+            QueryParamAccountIdLimit, QueryParamBlockLimit, QueryParamLimiter,
+            QueryParamNoteIdLimit, QueryParamNoteTagLimit, QueryParamNullifierPrefixLimit,
             account_info_from_row, account_summary_from_row, apply_delta, column_value_as_u64,
             get_nullifier_prefix, u64_to_value,
         },
@@ -119,6 +121,8 @@ pub fn select_accounts_by_block_range(
     block_end: BlockNumber,
     account_ids: &[AccountId],
 ) -> Result<Vec<AccountSummary>> {
+    QueryParamAccountIdLimit::check(account_ids.len())?;
+
     let mut stmt = transaction.prepare_cached(
         "
         SELECT
@@ -224,6 +228,8 @@ pub fn select_accounts_by_ids(
     transaction: &Transaction,
     account_ids: &[AccountId],
 ) -> Result<Vec<AccountInfo>> {
+    QueryParamAccountIdLimit::check(account_ids.len())?;
+
     let mut stmt = transaction.prepare_cached(
         "
         SELECT
@@ -710,6 +716,8 @@ pub fn select_nullifiers_by_prefix(
 ) -> Result<Vec<NullifierInfo>> {
     assert_eq!(prefix_len, 16, "Only 16-bit prefixes are supported");
 
+    QueryParamNullifierPrefixLimit::check(nullifier_prefixes.len())?;
+
     let nullifier_prefixes: Vec<Value> =
         nullifier_prefixes.iter().copied().map(Into::into).collect();
 
@@ -936,6 +944,8 @@ pub fn select_notes_by_id(
     transaction: &Transaction,
     note_ids: &[NoteId],
 ) -> Result<Vec<NoteRecord>> {
+    QueryParamNoteIdLimit::check(note_ids.len())?;
+
     let note_ids: Vec<Value> = note_ids.iter().map(|id| id.to_bytes().into()).collect();
 
     let mut stmt = transaction.prepare_cached(&format!(
@@ -965,6 +975,8 @@ pub fn select_note_inclusion_proofs(
     transaction: &Transaction,
     note_ids: BTreeSet<NoteId>,
 ) -> Result<BTreeMap<NoteId, NoteInclusionProof>> {
+    QueryParamNoteIdLimit::check(note_ids.len())?;
+
     let note_ids: Vec<Value> = note_ids.into_iter().map(|id| id.to_bytes().into()).collect();
 
     let mut select_notes_stmt = transaction.prepare_cached(
@@ -1124,6 +1136,13 @@ pub fn select_block_headers(
     transaction: &Transaction,
     blocks: impl Iterator<Item = BlockNumber> + Send,
 ) -> Result<Vec<BlockHeader>> {
+    // Best effort, the iterators are all deterministic `n+1`
+    // <https://doc.rust-lang.org/src/core/slice/iter/macros.rs.html#195>
+    // <https://doc.rust-lang.org/src/core/option.rs.html#2273>
+    // And the conjunction is truthful:
+    // <https://doc.rust-lang.org/src/core/iter/adapters/chain.rs.html#184>
+    QueryParamBlockLimit::check(blocks.size_hint().0)?;
+
     let blocks: Vec<Value> = blocks.map(|b| b.as_u32().into()).collect();
 
     let mut headers = Vec::with_capacity(blocks.len());
@@ -1205,6 +1224,8 @@ pub fn select_transactions_by_accounts_and_block_range(
     block_end: BlockNumber,
     account_ids: &[AccountId],
 ) -> Result<Vec<TransactionSummary>> {
+    QueryParamAccountIdLimit::check(account_ids.len())?;
+
     let account_ids: Vec<Value> = account_ids
         .iter()
         .copied()
@@ -1296,6 +1317,7 @@ pub fn get_note_sync(
     block_num: BlockNumber,
     note_tags: &[u32],
 ) -> Result<NoteSyncUpdate, NoteSyncError> {
+    QueryParamNoteTagLimit::check(note_tags.len())?;
     let notes = select_notes_since_block_by_tag_and_sender(transaction, note_tags, &[], block_num)?;
 
     let block_header =

--- a/crates/store/src/db/sql/utils.rs
+++ b/crates/store/src/db/sql/utils.rs
@@ -16,6 +16,51 @@ use crate::{
     errors::DatabaseError,
 };
 
+/// Checks limits against the desired query parameters, per query parameter and
+/// bails if they exceed a defined value.
+pub(crate) trait QueryParamLimiter {
+    /// Name of the parameter to mention in the error.
+    const PARAM_NAME: &'static str;
+    /// Limit that causes a bail if exceeded.
+    const LIMIT: usize;
+    /// Do the actual check.
+    fn check(dim: usize) -> Result<(), DatabaseError> {
+        if dim > Self::LIMIT {
+            Err(DatabaseError::TooManyFilterParameters { which: Self::PARAM_NAME, dim })?;
+        }
+        Ok(())
+    }
+}
+pub(crate) struct QueryParamAccountIdLimit;
+impl QueryParamLimiter for QueryParamAccountIdLimit {
+    const PARAM_NAME: &str = "account_id";
+    const LIMIT: usize = 1000;
+}
+
+pub(crate) struct QueryParamNullifierPrefixLimit;
+impl QueryParamLimiter for QueryParamNullifierPrefixLimit {
+    const PARAM_NAME: &str = "nullifier_prefix";
+    const LIMIT: usize = 1000;
+}
+
+pub(crate) struct QueryParamNoteTagLimit;
+impl QueryParamLimiter for QueryParamNoteTagLimit {
+    const PARAM_NAME: &str = "note_tag";
+    const LIMIT: usize = 1000;
+}
+
+pub(crate) struct QueryParamNoteIdLimit;
+impl QueryParamLimiter for QueryParamNoteIdLimit {
+    const PARAM_NAME: &str = "note_id";
+    const LIMIT: usize = 10_000;
+}
+
+pub(crate) struct QueryParamBlockLimit;
+impl QueryParamLimiter for QueryParamBlockLimit {
+    const PARAM_NAME: &str = "block_header";
+    const LIMIT: usize = 100_000;
+}
+
 /// Returns the high 16 bits of the provided nullifier.
 pub fn get_nullifier_prefix(nullifier: &Nullifier) -> u32 {
     (nullifier.most_significant_felt().as_int() >> 48) as u32

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -46,6 +46,8 @@ pub enum DatabaseError {
     NoteError(#[from] NoteError),
     #[error("SQLite error")]
     SqliteError(#[from] rusqlite::Error),
+    #[error("Too many filter parameters: {which} = {dim}")]
+    TooManyFilterParameters { which: &'static str, dim: usize },
 
     // OTHER ERRORS
     // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
The very most basic level to protect the database receiving invalid values that would cause excessive IO/CPU/time use of the store.