### PR TITLE
fix: stress-test assumed a -wal file exist from the get go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,6 +2402,7 @@ name = "miden-node-stress-test"
 version = "0.10.0"
 dependencies = [
  "clap 4.5.40",
+ "fs-err",
  "futures",
  "miden-air",
  "miden-block-prover",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ miden-air = { version = "0.15" }
 anyhow             = { version = "1.0" }
 assert_matches     = { version = "1.5" }
 async-trait        = { version = "0.1" }
+fs-err             = { version = "3" }
 futures            = { version = "0.3" }
 http               = { version = "1.3" }
 humantime          = { version = "2.2" }

--- a/bin/stress-test/Cargo.toml
+++ b/bin/stress-test/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 clap                      = { features = ["derive"], version = "4.5" }
+fs-err                    = { workspace = true }
 futures                   = { workspace = true }
 miden-air                 = { workspace = true }
 miden-block-prover        = { features = ["testing"], workspace = true }

--- a/bin/stress-test/src/seeding/metrics.rs
+++ b/bin/stress-test/src/seeding/metrics.rs
@@ -163,16 +163,13 @@ impl Display for SeedingMetrics {
 
 /// Gets the size of the store file and its WAL file.
 fn get_store_size(dump_file: &Path) -> u64 {
-    let store_file_size = fs_err::metadata(dump_file)
-        .unwrap_or_else(|_| panic!("Dumpfile always exists: {}", dump_file.display()))
-        .len();
+    let store_file_size = fs_err::metadata(dump_file).expect("Dumpfile always exists").len();
     let wal_file = format!("{}-wal", dump_file.to_str().unwrap());
-    let wal_file_size = fs_err::metadata(&wal_file).map_or_else(
-        |_err| {
+    let wal_file_size = fs_err::metadata(&wal_file)
+        .inspect_err(|_err| {
             eprintln!("No WAL file found: {wal_file}");
-            0
-        },
-        |meta| meta.len(),
-    );
+        })
+        .map(|m| m.len())
+        .unwrap_or_default();
     store_file_size + wal_file_size
 }

--- a/bin/stress-test/src/seeding/metrics.rs
+++ b/bin/stress-test/src/seeding/metrics.rs
@@ -163,8 +163,16 @@ impl Display for SeedingMetrics {
 
 /// Gets the size of the store file and its WAL file.
 fn get_store_size(dump_file: &Path) -> u64 {
-    let store_file_size = std::fs::metadata(dump_file).unwrap().len();
-    let wal_file_size =
-        std::fs::metadata(format!("{}-wal", dump_file.to_str().unwrap())).unwrap().len();
+    let store_file_size = fs_err::metadata(dump_file)
+        .unwrap_or_else(|_| panic!("Dumpfile always exists: {}", dump_file.display()))
+        .len();
+    let wal_file = format!("{}-wal", dump_file.to_str().unwrap());
+    let wal_file_size = fs_err::metadata(&wal_file).map_or_else(
+        |_err| {
+            eprintln!("No WAL file found: {wal_file}");
+            0
+        },
+        |meta| meta.len(),
+    );
     store_file_size + wal_file_size
 }


### PR DESCRIPTION
Address an assumption that doesn't hold for sqlite 3.46.1 as shipped with fedora 41