### PR TITLE
feat: support gRPC server reflection v1 alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Replaced integer-based duration args with human-readable duration strings (#998 & #1014).
 - [BREAKING] Refactor the `miden-proving-service` proxy status service to use gRPC instead of HTTP (#953).
 - Added configurable network id for the faucet (#1016).
+- Support gRPC server relection `v1alpha` (#1036).
 
 ### Changes
 

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -252,11 +252,21 @@ impl BlockProducerRpcServer {
             .build_v1()
             .context("failed to build reflection service")?;
 
+        // This is currently required for postman to work properly because
+        // it doesn't support the new version yet.
+        //
+        // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
+        let reflection_service_alpha = tonic_reflection::server::Builder::configure()
+            .register_file_descriptor_set(block_producer_api_descriptor())
+            .build_v1()
+            .context("failed to build reflection service")?;
+
         // Build the gRPC server with the API service and trace layer.
         tonic::transport::Server::builder()
             .layer(TraceLayer::new_for_grpc().make_span_with(block_producer_trace_fn))
             .add_service(api_server::ApiServer::new(self))
             .add_service(reflection_service)
+            .add_service(reflection_service_alpha)
             .serve_with_incoming(TcpListenerStream::new(listener))
             .await
             .context("failed to serve block producer API")

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -258,7 +258,7 @@ impl BlockProducerRpcServer {
         // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
         let reflection_service_alpha = tonic_reflection::server::Builder::configure()
             .register_file_descriptor_set(block_producer_api_descriptor())
-            .build_v1()
+            .build_v1alpha()
             .context("failed to build reflection service")?;
 
         // Build the gRPC server with the API service and trace layer.

--- a/crates/ntx-builder/src/builder/mod.rs
+++ b/crates/ntx-builder/src/builder/mod.rs
@@ -119,12 +119,22 @@ impl NetworkTransactionBuilder {
             .build_v1()
             .context("failed to build reflection service")?;
 
+        // This is currently required for postman to work properly because
+        // it doesn't support the new version yet.
+        //
+        // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
+        let reflection_service_alpha = tonic_reflection::server::Builder::configure()
+            .register_file_descriptor_set(ntx_builder_api_descriptor())
+            .build_v1()
+            .context("failed to build reflection service")?;
+
         let listener = TcpListener::bind(self.ntx_builder_address).await?;
         let server = tonic::transport::Server::builder()
             .accept_http1(true)
             .layer(TraceLayer::new_for_grpc())
             .add_service(api_server::ApiServer::new(NtxBuilderApi::new(notes_queue.clone())))
             .add_service(reflection_service)
+            .add_service(reflection_service_alpha)
             .serve_with_incoming(TcpListenerStream::new(listener));
         tokio::pin!(server);
 

--- a/crates/ntx-builder/src/builder/mod.rs
+++ b/crates/ntx-builder/src/builder/mod.rs
@@ -125,7 +125,7 @@ impl NetworkTransactionBuilder {
         // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
         let reflection_service_alpha = tonic_reflection::server::Builder::configure()
             .register_file_descriptor_set(ntx_builder_api_descriptor())
-            .build_v1()
+            .build_v1alpha()
             .context("failed to build reflection service")?;
 
         let listener = TcpListener::bind(self.ntx_builder_address).await?;

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -47,7 +47,7 @@ impl Rpc {
         // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
         let reflection_service_alpha = server::Builder::configure()
             .register_file_descriptor_set(rpc_api_descriptor())
-            .build_v1()
+            .build_v1alpha()
             .context("failed to build reflection service")?;
 
         info!(target: COMPONENT, endpoint=?self.listener, store=%self.store, block_producer=?self.block_producer, "Server initialized");

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -41,6 +41,15 @@ impl Rpc {
             .build_v1()
             .context("failed to build reflection service")?;
 
+        // This is currently required for postman to work properly because
+        // it doesn't support the new version yet.
+        //
+        // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
+        let reflection_service_alpha = server::Builder::configure()
+            .register_file_descriptor_set(rpc_api_descriptor())
+            .build_v1()
+            .context("failed to build reflection service")?;
+
         info!(target: COMPONENT, endpoint=?self.listener, store=%self.store, block_producer=?self.block_producer, "Server initialized");
 
         tonic::transport::Server::builder()
@@ -53,6 +62,7 @@ impl Rpc {
             .add_service(api_service)
             // Enables gRPC reflection service.
             .add_service(reflection_service)
+            .add_service(reflection_service_alpha)
             .serve_with_incoming(TcpListenerStream::new(self.listener))
             .await
             .context("failed to serve RPC API")

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -106,6 +106,15 @@ impl Store {
             .build_v1()
             .context("failed to build reflection service")?;
 
+        // This is currently required for postman to work properly because
+        // it doesn't support the new version yet.
+        //
+        // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
+        let reflection_service_alpha = tonic_reflection::server::Builder::configure()
+            .register_file_descriptor_set(store_api_descriptor())
+            .build_v1()
+            .context("failed to build reflection service")?;
+
         info!(target: COMPONENT, "Database loaded");
 
         tokio::spawn(db_maintenance_service.run());
@@ -116,6 +125,7 @@ impl Store {
             .add_service(ntx_builder_service)
             .add_service(block_producer_service)
             .add_service(reflection_service)
+            .add_service(reflection_service_alpha)
             .serve_with_incoming(TcpListenerStream::new(self.listener))
             .await
             .context("failed to serve store API")

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -112,7 +112,7 @@ impl Store {
         // See: <https://github.com/postmanlabs/postman-app-support/issues/13120>.
         let reflection_service_alpha = tonic_reflection::server::Builder::configure()
             .register_file_descriptor_set(store_api_descriptor())
-            .build_v1()
+            .build_v1alpha()
             .context("failed to build reflection service")?;
 
         info!(target: COMPONENT, "Database loaded");


### PR DESCRIPTION
This adds support for gRPC server reflection `v1alpha` as an addition to the already supported `v1`.

This version is deprecated but not all external applications have migrated. Notably, this includes `postman` which doesn't work our RPC endpoint currently due to this.

The tracking issue for postman is https://github.com/postmanlabs/postman-app-support/issues/13120. Once this is closed and released we can consider reverting this support, though there probably isn't much harm in simply keeping it until its formally removed in `tonic` etc.