### PR TITLE
chore: bump base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2083,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#76ca26ca07fd9174b02211b643243afc198c40cf"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#76ca26ca07fd9174b02211b643243afc198c40cf"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#76ca26ca07fd9174b02211b643243afc198c40cf"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#76ca26ca07fd9174b02211b643243afc198c40cf"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2598,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#76ca26ca07fd9174b02211b643243afc198c40cf"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#76ca26ca07fd9174b02211b643243afc198c40cf"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -4006,7 +4006,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4019,7 +4019,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4561,7 +4561,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5530,7 +5530,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This should _hopefully_ fix the CI/build issues once everyone is up to this point.

I'm actually curious if the build itself passes with the poisoned gh cache.