### PR TITLE
fix: update `miden-lib` and use `LexicographicWord` in store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2601,6 +2601,7 @@ dependencies = [
  "miden-tx",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
+ "thiserror 2.0.12",
  "winter-maybe-async",
  "winterfell",
 ]
@@ -2608,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2624,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c4249183a790b0b0cfc7d44e5e31500533712d33"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -4016,7 +4017,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4029,7 +4030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4571,7 +4572,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5540,7 +5541,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#b6e08dbb64282f31718f1e5400887ed69db4c599"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#b6e08dbb64282f31718f1e5400887ed69db4c599"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#b6e08dbb64282f31718f1e5400887ed69db4c599"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#b6e08dbb64282f31718f1e5400887ed69db4c599"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#b6e08dbb64282f31718f1e5400887ed69db4c599"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.10.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#a57860a99430dbfbae6b04860637b2af7e70bed9"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#b6e08dbb64282f31718f1e5400887ed69db4c599"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -4017,7 +4017,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4030,7 +4030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4572,7 +4572,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5541,7 +5541,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -151,13 +151,8 @@ impl StoreCommand {
         //
         // The genesis block is special in that accounts are "deplyed" without transactions and
         // therefore we need bump the nonce manually to uphold this invariant.
-        let updated_account = Account::from_parts(
-            account.id(),
-            account.vault().clone(),
-            account.storage().clone(),
-            account.code().clone(),
-            ONE,
-        );
+        let (id, vault, sorage, code, _) = account.into_parts();
+        let updated_account = Account::from_parts(id, vault, sorage, code, ONE);
 
         Ok(AccountFile::new(
             updated_account,

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -11,7 +11,7 @@ use miden_node_store::{GenesisState, Store};
 use miden_node_utils::{crypto::get_rpo_random_coin, grpc::UrlExt};
 use miden_objects::{
     Felt, ONE,
-    account::{AccountFile, AuthSecretKey},
+    account::{Account, AccountFile, AuthSecretKey},
     asset::TokenSymbol,
     crypto::dsa::rpo_falcon512::SecretKey,
 };
@@ -134,7 +134,7 @@ impl StoreCommand {
         let max_supply = Felt::try_from(max_supply).expect("max supply is less than field modulus");
 
         // Create the faucet.
-        let (mut account, account_seed) = create_basic_fungible_faucet(
+        let (account, account_seed) = create_basic_fungible_faucet(
             rng.random(),
             TokenSymbol::try_from("MIDEN").expect("MIDEN is a valid token symbol"),
             decimals,
@@ -151,10 +151,16 @@ impl StoreCommand {
         //
         // The genesis block is special in that accounts are "deplyed" without transactions and
         // therefore we need bump the nonce manually to uphold this invariant.
-        account.set_nonce(ONE).context("failed to set account nonce to 1")?;
+        let updated_account = Account::from_parts(
+            account.id(),
+            account.vault().clone(),
+            account.storage().clone(),
+            account.code().clone(),
+            ONE,
+        );
 
         Ok(AccountFile::new(
-            account,
+            updated_account,
             Some(account_seed),
             vec![AuthSecretKey::RpoFalcon512(secret)],
         ))

--- a/bin/remote-prover/src/api/prover.rs
+++ b/bin/remote-prover/src/api/prover.rs
@@ -234,10 +234,7 @@ mod test {
     use miden_objects::{
         asset::{Asset, FungibleAsset},
         note::NoteType,
-        testing::{
-            account_code::DEFAULT_AUTH_SCRIPT,
-            account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_SENDER},
-        },
+        testing::account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_SENDER},
         transaction::{ProvenTransaction, TransactionScript, TransactionWitness},
     };
     use miden_testing::{Auth, MockChain};
@@ -296,9 +293,15 @@ mod test {
             )
             .unwrap();
 
-        let tx_script =
-            TransactionScript::compile(DEFAULT_AUTH_SCRIPT, TransactionKernel::assembler())
-                .unwrap();
+        let tx_script = TransactionScript::compile(
+            "begin
+                padw padw padw padw
+                call.::miden::contracts::auth::basic::auth__tx_rpo_falcon512
+                dropw dropw dropw dropw
+            end",
+            TransactionKernel::assembler(),
+        )
+        .unwrap();
         let tx_context = mock_chain
             .build_tx_context(account.id(), &[], &[])
             .unwrap()

--- a/bin/remote-prover/src/api/prover.rs
+++ b/bin/remote-prover/src/api/prover.rs
@@ -301,6 +301,7 @@ mod test {
                 .unwrap();
         let tx_context = mock_chain
             .build_tx_context(account.id(), &[], &[])
+            .unwrap()
             .extend_input_notes(vec![note_1])
             .tx_script(tx_script)
             .build();

--- a/bin/remote-prover/src/api/prover.rs
+++ b/bin/remote-prover/src/api/prover.rs
@@ -295,9 +295,7 @@ mod test {
 
         let tx_script = TransactionScript::compile(
             "begin
-                padw padw padw padw
                 call.::miden::contracts::auth::basic::auth__tx_rpo_falcon512
-                dropw dropw dropw dropw
             end",
             TransactionKernel::assembler(),
         )

--- a/crates/block-producer/src/server.rs
+++ b/crates/block-producer/src/server.rs
@@ -524,6 +524,7 @@ mod test {
             ),
             Digest::default(),
             [i; 32].try_into().unwrap(),
+            Digest::default(),
             0.into(),
             Digest::default(),
             u32::MAX.into(),

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -135,6 +135,7 @@ impl MockProvenTxBuilder {
             self.account_id,
             self.initial_account_commitment,
             self.final_account_commitment,
+            Digest::default(),
             BlockNumber::from(0),
             Digest::default(),
             self.expiration_block_num,

--- a/crates/ntx-builder/src/builder/data_store/account_cache.rs
+++ b/crates/ntx-builder/src/builder/data_store/account_cache.rs
@@ -54,8 +54,10 @@ impl NetworkAccountCache {
 mod tests {
     use std::{num::NonZeroUsize, sync::Arc};
 
-    use miden_lib::transaction::TransactionKernel;
-    use miden_objects::{Felt, account::Account};
+    use miden_lib::{account::auth::RpoFalcon512, transaction::TransactionKernel};
+    use miden_objects::{
+        EMPTY_WORD, Felt, account::Account, crypto::dsa::rpo_falcon512::PublicKey,
+    };
 
     use crate::builder::data_store::NetworkAccountCache;
 
@@ -195,6 +197,7 @@ mod tests {
         Account::mock(
             (u128::from(id) << 99) | (storage_mode << 70),
             Felt::new(0),
+            RpoFalcon512::new(PublicKey::new(EMPTY_WORD)),
             TransactionKernel::testing_assembler(),
         )
     }

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -536,7 +536,12 @@ pub fn upsert_accounts(
     Ok(count)
 }
 
+/// Builds an [`AccountDelta`] from the given [`Account`].
+///
+/// This function should only be used when inserting a new account into the DB.The returned delta
+/// could be thought of as the difference between an "empty transaction" and the it's initial state.
 fn build_insert_delta(account: &Account) -> Result<AccountDelta, DatabaseError> {
+    // Build storage delta
     let mut values = BTreeMap::new();
     let mut maps = BTreeMap::new();
     for (slot_idx, slot) in account.storage().clone().into_iter().enumerate() {
@@ -554,6 +559,7 @@ fn build_insert_delta(account: &Account) -> Result<AccountDelta, DatabaseError> 
     }
     let storage_delta = AccountStorageDelta::from_parts(values, maps)?;
 
+    // Build vault delta
     let mut fungible = BTreeMap::new();
     let mut non_fungible = BTreeMap::new();
     for asset in account.vault().assets() {

--- a/crates/store/src/db/sql/mod.rs
+++ b/crates/store/src/db/sql/mod.rs
@@ -16,7 +16,7 @@ use miden_objects::{
     account::{
         AccountDelta, AccountId, AccountStorageDelta, AccountVaultDelta, FungibleAssetDelta,
         NonFungibleAssetDelta, NonFungibleDeltaAction, StorageMapDelta,
-        delta::AccountUpdateDetails,
+        delta::{AccountUpdateDetails, LexicographicWord},
     },
     asset::NonFungibleAsset,
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNumber},
@@ -394,6 +394,7 @@ pub fn select_account_delta(
 
         match storage_maps.entry(slot) {
             Entry::Vacant(entry) => {
+                let key = LexicographicWord::new(key);
                 entry.insert(StorageMapDelta::new(BTreeMap::from([(key, value)])));
             },
             Entry::Occupied(mut entry) => {
@@ -598,7 +599,7 @@ fn insert_account_delta(
                 account_id.to_bytes(),
                 block_number.as_u32(),
                 slot,
-                key.to_bytes(),
+                key.inner().to_bytes(),
                 value.to_bytes(),
             ])?;
         }

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -6,10 +6,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use miden_lib::{note::create_p2id_note, transaction::TransactionKernel};
+use miden_lib::{
+    account::auth::RpoFalcon512, note::create_p2id_note, transaction::TransactionKernel,
+};
 use miden_node_proto::domain::account::AccountSummary;
 use miden_objects::{
-    Felt, FieldElement, Word, ZERO,
+    EMPTY_WORD, Felt, FieldElement, Word, ZERO,
     account::{
         Account, AccountBuilder, AccountComponent, AccountDelta, AccountId, AccountIdVersion,
         AccountStorageDelta, AccountStorageMode, AccountType, AccountVaultDelta, StorageSlot,
@@ -17,7 +19,10 @@ use miden_objects::{
     },
     asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails},
     block::{BlockAccountUpdate, BlockHeader, BlockNoteIndex, BlockNoteTree, BlockNumber},
-    crypto::{hash::rpo::RpoDigest, merkle::MerklePath, rand::RpoRandomCoin},
+    crypto::{
+        dsa::rpo_falcon512::PublicKey, hash::rpo::RpoDigest, merkle::MerklePath,
+        rand::RpoRandomCoin,
+    },
     note::{
         Note, NoteDetails, NoteExecutionHint, NoteId, NoteMetadata, NoteTag, NoteType, Nullifier,
     },
@@ -606,7 +611,7 @@ fn sql_public_account_details() {
     let vault_delta = AccountVaultDelta::from_iters([nft2], [nft1]);
 
     let mut delta2 =
-        AccountDelta::new(account.id(), storage_delta, vault_delta, Some(Felt::new(2))).unwrap();
+        AccountDelta::new(account.id(), storage_delta, vault_delta, Felt::new(2)).unwrap();
 
     account.apply_delta(&delta2).unwrap();
 
@@ -650,7 +655,7 @@ fn sql_public_account_details() {
         account.id(),
         storage_delta3,
         AccountVaultDelta::from_iters([nft1], []),
-        Some(Felt::new(3)),
+        Felt::new(3),
     )
     .unwrap();
 
@@ -1239,6 +1244,7 @@ fn mock_account_code_and_storage(
         .storage_mode(storage_mode)
         .with_assets(assets)
         .with_component(component)
+        .with_auth_component(RpoFalcon512::new(PublicKey::new(EMPTY_WORD)))
         .build_existing()
         .unwrap()
 }


### PR DESCRIPTION
This PR updates the `miden-lib` dependencies and fixes the generated build errors. Mainly the use of `LexicographicWord` in the store. 

The lock file was updated with `cargo update -p miden-lib` so the changes are only related to this base update.