### PR TITLE
bug: Fix Otel output for ProposedBlock

### DIFF
--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -411,7 +411,7 @@ impl TelemetryInjectorExt for ProposedBlock {
                 .expect("should have less than u32::MAX output notes"),
         );
 
-        let num_batch_created_notes = self.batches().num_created_notes();
+        let num_batch_created_notes = self.output_note_batches().len();
         span.set_attribute(
             "block.batches.output_notes.count",
             u32::try_from(num_batch_created_notes)

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -408,14 +408,14 @@ impl TelemetryInjectorExt for ProposedBlock {
         span.set_attribute(
             "block.output_notes.count",
             u32::try_from(num_block_created_notes)
-                .expect("should have less than u32::MAX output notes"),
+                .expect("should have less than u32::MAX block output notes"),
         );
 
         let num_batch_created_notes = self.output_note_batches().len();
         span.set_attribute(
             "block.batches.output_notes.count",
             u32::try_from(num_batch_created_notes)
-                .expect("should have less than u32::MAX erased notes"),
+                .expect("should have less than u32::MAX batch output notes"),
         );
 
         let num_erased_notes = num_batch_created_notes


### PR DESCRIPTION
## Context

Closes #793.

Tracing values currently use the wrong value for  `block.batches.output_notes.count`.

## Changes

- Fix `block.batches.output_notes.count` value.
- Fix related expect message.