### PR TITLE
Add OnFailure impl and add to RPC trace layer

### DIFF
--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -4,7 +4,10 @@ use accept::AcceptLayer;
 use anyhow::Context;
 use miden_node_proto::generated::rpc::api_server;
 use miden_node_proto_build::rpc_api_descriptor;
-use miden_node_utils::{cors::cors_for_grpc_web_layer, tracing::grpc::rpc_trace_fn};
+use miden_node_utils::{
+    cors::cors_for_grpc_web_layer,
+    tracing::grpc::{OnFailure, rpc_trace_fn},
+};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic_reflection::server;
@@ -52,9 +55,12 @@ impl Rpc {
 
         info!(target: COMPONENT, endpoint=?self.listener, store=%self.store, block_producer=?self.block_producer, "Server initialized");
 
+        // Initialize tracing layer.
+        let trace_layer =
+            TraceLayer::new_for_grpc().make_span_with(rpc_trace_fn).on_failure(OnFailure {});
         tonic::transport::Server::builder()
             .accept_http1(true)
-            .layer(TraceLayer::new_for_grpc().make_span_with(rpc_trace_fn))
+            .layer(trace_layer)
             .layer(AcceptLayer::new()?)
             .layer(cors_for_grpc_web_layer())
             // Enables gRPC-web support.

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -55,9 +55,11 @@ impl Rpc {
 
         info!(target: COMPONENT, endpoint=?self.listener, store=%self.store, block_producer=?self.block_producer, "Server initialized");
 
-        // Initialize tracing layer.
+        // Initialize trace layer.
         let trace_layer =
             TraceLayer::new_for_grpc().make_span_with(rpc_trace_fn).on_failure(OnFailure {});
+
+        // Build the server.
         tonic::transport::Server::builder()
             .accept_http1(true)
             .layer(trace_layer)


### PR DESCRIPTION
## Context

Closes #1050.

AWS load balancers hit our RPC server with a request expecting gRPC status code 12. This occurs as expected. But our stack also logs an error event when this happens because of the way the tracing crate's `DefaultOnFailure` type implements the `OnFailure` trait.

This means our dashboards are muddied with constant (30s interval healthcheck) error events.

## Changes

- Add an `OnFailure` struct which implements tracing crate's `OnFailure` trait.
    - Logs DEBUG events for gRPC status code 12 situations.
- Integrate the `OnFailure` struct to the RPC server tracing layer.