### PR TITLE
feat: Add trace layer to remote prover and proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "tonic-build",
  "tonic-health",
  "tonic-web",
+ "tower-http",
  "tracing",
  "uuid",
 ]

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 [dependencies]
 anyhow                = { workspace = true }
 async-trait           = { version = "0.1" }
+tower-http             = { features = ["trace"], workspace = true }
 axum                  = { version = "0.8" }
 bytes                 = { version = "1.0" }
 clap                  = { features = ["derive", "env"], version = "4.5" }

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -25,7 +25,6 @@ workspace = true
 [dependencies]
 anyhow                = { workspace = true }
 async-trait           = { version = "0.1" }
-tower-http             = { features = ["trace"], workspace = true }
 axum                  = { version = "0.8" }
 bytes                 = { version = "1.0" }
 clap                  = { features = ["derive", "env"], version = "4.5" }
@@ -52,6 +51,7 @@ tokio-stream          = { features = ["net"], version = "0.1" }
 tonic                 = { default-features = false, features = ["codegen", "prost", "router", "transport"], version = "0.13" }
 tonic-health          = { version = "0.13" }
 tonic-web             = { version = "0.13" }
+tower-http            = { features = ["trace"], workspace = true }
 tracing               = { version = "0.1" }
 uuid                  = { features = ["v4"], version = "1.16" }
 

--- a/bin/remote-prover/src/commands/worker.rs
+++ b/bin/remote-prover/src/commands/worker.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use miden_node_utils::cors::cors_for_grpc_web_layer;
+use miden_node_utils::{cors::cors_for_grpc_web_layer, tracing::grpc::remote_prover_trace_fn};
 use miden_remote_prover::{
     COMPONENT,
     api::{ProofType, RpcListener},
@@ -9,6 +9,7 @@ use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic_health::server::health_reporter;
 use tonic_web::GrpcWebLayer;
+use tower_http::trace::TraceLayer;
 use tracing::{info, instrument};
 
 /// Starts a worker.
@@ -61,6 +62,7 @@ impl StartWorker {
 
         tonic::transport::Server::builder()
             .accept_http1(true)
+            .layer(TraceLayer::new_for_grpc().make_span_with(remote_prover_trace_fn))
             .layer(cors_for_grpc_web_layer())
             .layer(GrpcWebLayer::new())
             .add_service(rpc.api_service)

--- a/bin/remote-prover/src/commands/worker.rs
+++ b/bin/remote-prover/src/commands/worker.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use miden_node_utils::{cors::cors_for_grpc_web_layer, tracing::grpc::remote_prover_trace_fn};
+use miden_node_utils::{
+    cors::cors_for_grpc_web_layer,
+    tracing::grpc::{TracedComponent, traced_span_fn},
+};
 use miden_remote_prover::{
     COMPONENT,
     api::{ProofType, RpcListener},
@@ -62,7 +65,10 @@ impl StartWorker {
 
         tonic::transport::Server::builder()
             .accept_http1(true)
-            .layer(TraceLayer::new_for_grpc().make_span_with(remote_prover_trace_fn))
+            .layer(
+                TraceLayer::new_for_grpc()
+                    .make_span_with(traced_span_fn(TracedComponent::RemoteProver)),
+            )
             .layer(cors_for_grpc_web_layer())
             .layer(GrpcWebLayer::new())
             .add_service(rpc.api_service)

--- a/bin/remote-prover/src/proxy/status.rs
+++ b/bin/remote-prover/src/proxy/status.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use miden_node_utils::tracing::grpc::remote_prover_proxy_trace_fn;
 use miden_remote_prover::{
     api::ProofType,
     generated::remote_prover::{
@@ -12,6 +13,7 @@ use pingora::{server::ListenFds, services::Service};
 use tokio::{net::TcpListener, sync::watch, time::interval};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status, transport::Server};
+use tower_http::trace::TraceLayer;
 use tracing::{error, info, instrument};
 
 use super::worker::WorkerHealthStatus;
@@ -138,13 +140,13 @@ impl Service for ProxyStatusPingoraService {
         // Build the tonic server with self as the gRPC API implementation
         let status_server = ProxyStatusApiServer::new(self.clone());
         let mut server_shutdown = shutdown.clone();
-        let server = Server::builder().add_service(status_server).serve_with_incoming_shutdown(
-            TcpListenerStream::new(listener),
-            async move {
+        let server = Server::builder()
+            .layer(TraceLayer::new_for_grpc().make_span_with(remote_prover_proxy_trace_fn))
+            .add_service(status_server)
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
                 let _ = server_shutdown.changed().await;
                 info!("gRPC status service received shutdown signal");
-            },
-        );
+            });
 
         // Run both the server and updater concurrently, if either fails, the whole service stops
         tokio::select! {

--- a/bin/remote-prover/src/proxy/status.rs
+++ b/bin/remote-prover/src/proxy/status.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use miden_node_utils::tracing::grpc::remote_prover_proxy_trace_fn;
+use miden_node_utils::tracing::grpc::{TracedComponent, traced_span_fn};
 use miden_remote_prover::{
     api::ProofType,
     generated::remote_prover::{
@@ -141,7 +141,10 @@ impl Service for ProxyStatusPingoraService {
         let status_server = ProxyStatusApiServer::new(self.clone());
         let mut server_shutdown = shutdown.clone();
         let server = Server::builder()
-            .layer(TraceLayer::new_for_grpc().make_span_with(remote_prover_proxy_trace_fn))
+            .layer(
+                TraceLayer::new_for_grpc()
+                    .make_span_with(traced_span_fn(TracedComponent::RemoteProverProxy)),
+            )
             .add_service(status_server)
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
                 let _ = server_shutdown.changed().await;

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -16,7 +16,7 @@ use miden_node_proto::{
 use miden_node_proto_build::block_producer_api_descriptor;
 use miden_node_utils::{
     formatting::{format_input_notes, format_output_notes},
-    tracing::grpc::{OtelInterceptor, block_producer_trace_fn},
+    tracing::grpc::{OtelInterceptor, TracedComponent, traced_span_fn},
 };
 use miden_objects::{
     block::BlockNumber, note::Nullifier, transaction::ProvenTransaction,
@@ -321,7 +321,10 @@ impl BlockProducerRpcServer {
 
         // Build the gRPC server with the API service and trace layer.
         tonic::transport::Server::builder()
-            .layer(TraceLayer::new_for_grpc().make_span_with(block_producer_trace_fn))
+            .layer(
+                TraceLayer::new_for_grpc()
+                    .make_span_with(traced_span_fn(TracedComponent::StoreBlockProducer)),
+            )
             .add_service(api_server::ApiServer::new(self))
             .add_service(reflection_service)
             .add_service(reflection_service_alpha)

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -4,7 +4,10 @@ use accept::AcceptLayer;
 use anyhow::Context;
 use miden_node_proto::generated::rpc::api_server;
 use miden_node_proto_build::rpc_api_descriptor;
-use miden_node_utils::{cors::cors_for_grpc_web_layer, tracing::grpc::rpc_trace_fn};
+use miden_node_utils::{
+    cors::cors_for_grpc_web_layer,
+    tracing::grpc::{TracedComponent, traced_span_fn},
+};
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic_reflection::server;
@@ -54,7 +57,7 @@ impl Rpc {
 
         tonic::transport::Server::builder()
             .accept_http1(true)
-            .layer(TraceLayer::new_for_grpc().make_span_with(rpc_trace_fn))
+            .layer(TraceLayer::new_for_grpc().make_span_with(traced_span_fn(TracedComponent::Rpc)))
             .layer(AcceptLayer::new()?)
             .layer(cors_for_grpc_web_layer())
             // Enables gRPC-web support.

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -7,9 +7,7 @@ use std::{
 use anyhow::Context;
 use miden_node_proto::generated::store;
 use miden_node_proto_build::store_api_descriptor;
-use miden_node_utils::tracing::grpc::{
-    store_block_producer_trace_fn, store_ntx_builder_trace_fn, store_rpc_trace_fn,
-};
+use miden_node_utils::tracing::grpc::{TracedComponent, traced_span_fn};
 use tokio::{net::TcpListener, task::JoinSet};
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::trace::TraceLayer;
@@ -134,7 +132,10 @@ impl Store {
         // Build the gRPC server with the API services and trace layer.
         join_set.spawn(
             tonic::transport::Server::builder()
-                .layer(TraceLayer::new_for_grpc().make_span_with(store_rpc_trace_fn))
+                .layer(
+                    TraceLayer::new_for_grpc()
+                        .make_span_with(traced_span_fn(TracedComponent::StoreRpc)),
+                )
                 .add_service(rpc_service)
                 .add_service(reflection_service.clone())
                 .add_service(reflection_service_alpha.clone())
@@ -143,7 +144,10 @@ impl Store {
 
         join_set.spawn(
             tonic::transport::Server::builder()
-                .layer(TraceLayer::new_for_grpc().make_span_with(store_ntx_builder_trace_fn))
+                .layer(
+                    TraceLayer::new_for_grpc()
+                        .make_span_with(traced_span_fn(TracedComponent::StoreNtxBuilder)),
+                )
                 .add_service(ntx_builder_service)
                 .add_service(reflection_service.clone())
                 .add_service(reflection_service_alpha.clone())
@@ -152,7 +156,10 @@ impl Store {
 
         join_set.spawn(
             tonic::transport::Server::builder()
-                .layer(TraceLayer::new_for_grpc().make_span_with(store_block_producer_trace_fn))
+                .layer(
+                    TraceLayer::new_for_grpc()
+                        .make_span_with(traced_span_fn(TracedComponent::BlockProducer)),
+                )
                 .add_service(block_producer_service)
                 .add_service(reflection_service)
                 .add_service(reflection_service_alpha)

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -9,7 +9,7 @@ macro_rules! rpc_span {
     };
 }
 
-/// Represents an Otel compatible, traced Miden compoent.
+/// Represents an Otel compatible, traced Miden component.
 ///
 /// Used to select an appropriate [`tracing::Span`] for the tonic server to use.
 #[derive(Copy, Clone)]

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -9,13 +9,39 @@ macro_rules! rpc_span {
     };
 }
 
-/// A [`trace_fn`](tonic::transport::server::Server) implementation for the RPC which
+/// Represents an Otel compatible, traced Miden compoent.
+///
+/// Used to select an appropriate [`tracing::Span`] for the tonic server to use.
+#[derive(Copy, Clone)]
+pub enum TracedComponent {
+    Rpc,
+    BlockProducer,
+    StoreRpc,
+    StoreBlockProducer,
+    StoreNtxBuilder,
+    RemoteProver,
+    RemoteProverProxy,
+}
+
+/// Returns a [`trace_fn`](tonic::transport::server::Server) implementation for the RPC which
 /// adds open-telemetry information to the span.
 ///
-/// Creates an `info` span following the open-telemetry standard: `rpc.rpc/{method}`.
+/// Creates an `info` span following the open-telemetry standard: `{service}.rpc/{method}`.
 /// Additionally also pulls in remote tracing context which allows the server trace to be connected
 /// to the client's origin trace.
-pub fn rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+pub fn traced_span_fn<T>(svc: TracedComponent) -> fn(&http::Request<T>) -> tracing::Span {
+    match svc {
+        TracedComponent::Rpc => rpc_trace_fn,
+        TracedComponent::BlockProducer => block_producer_trace_fn,
+        TracedComponent::StoreRpc => store_rpc_trace_fn,
+        TracedComponent::StoreBlockProducer => store_block_producer_trace_fn,
+        TracedComponent::StoreNtxBuilder => store_ntx_builder_trace_fn,
+        TracedComponent::RemoteProver => remote_prover_trace_fn,
+        TracedComponent::RemoteProverProxy => remote_prover_proxy_trace_fn,
+    }
+}
+
+fn rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     let span = match request.uri().path().rsplit('/').next() {
         Some("CheckNullifiers") => rpc_span!("rpc.rpc", "CheckNullifiers"),
         Some("CheckNullifiersByPrefix") => rpc_span!("rpc.rpc", "CheckNullifiersByPrefix"),
@@ -34,13 +60,7 @@ pub fn rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     add_network_attributes(span, request)
 }
 
-/// A [`trace_fn`](tonic::transport::server::Server) implementation for the block producer which
-/// adds open-telemetry information to the span.
-///
-/// Creates an `info` span following the open-telemetry standard: `block-producer.rpc/{method}`.
-/// Additionally also pulls in remote tracing context which allows the server trace to be connected
-/// to the client's origin trace.
-pub fn block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+fn block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     let span = match request.uri().path().rsplit('/').next() {
         Some("SubmitProvenTransaction") => {
             rpc_span!("block-producer.rpc", "SubmitProvenTransaction")
@@ -55,13 +75,7 @@ pub fn block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     add_network_attributes(span, request)
 }
 
-/// A [`trace_fn`](tonic::transport::server::Server) implementation for the store's RPC API which
-/// adds open-telemetry information to the span.
-///
-/// Creates an `info` span following the open-telemetry standard: `store.rpc.rpc/{method}`.
-/// Additionally also pulls in remote tracing context which allows the server trace to be connected
-/// to the client's origin trace.
-pub fn store_rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+fn store_rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     let method = request.uri().path().rsplit('/').next().unwrap_or("Unknown");
     let span = match method {
         "CheckNullifiers" => rpc_span!("store.rpc.rpc", "CheckNullifiers"),
@@ -82,13 +96,7 @@ pub fn store_rpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     add_network_attributes(span, request)
 }
 
-/// A [`trace_fn`](tonic::transport::server::Server) implementation for the store's block-producer
-/// API which adds open-telemetry information to the span.
-///
-/// Creates an `info` span following the open-telemetry standard:
-/// `store.block-producer.rpc/{method}`. Additionally also pulls in remote tracing context which
-/// allows the server trace to be connected to the client's origin trace.
-pub fn store_block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+fn store_block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     let method = request.uri().path().rsplit('/').next().unwrap_or("Unknown");
     let span = match method {
         "ApplyBlock" => rpc_span!("store.block-producer.rpc", "ApplyBlock"),
@@ -103,13 +111,7 @@ pub fn store_block_producer_trace_fn<T>(request: &http::Request<T>) -> tracing::
     add_network_attributes(span, request)
 }
 
-/// A [`trace_fn`](tonic::transport::server::Server) implementation for the store's ntx-builder API
-/// which adds open-telemetry information to the span.
-///
-/// Creates an `info` span following the open-telemetry standard: `store.ntx-builder.rpc/{method}`.
-/// Additionally also pulls in remote tracing context which allows the server trace to be connected
-/// to the client's origin trace.
-pub fn store_ntx_builder_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+fn store_ntx_builder_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     let method = request.uri().path().rsplit('/').next().unwrap_or("Unknown");
     let span = match method {
         "GetBlockHeaderByNumber" => rpc_span!("store.ntx-builder.rpc", "GetBlockHeaderByNumber"),
@@ -123,6 +125,30 @@ pub fn store_ntx_builder_trace_fn<T>(request: &http::Request<T>) -> tracing::Spa
             rpc_span!("store.ntx-builder.rpc", "GetNetworkAccountDetailsByPrefix")
         },
         _ => rpc_span!("store.ntx-builder.rpc", "Unknown"),
+    };
+
+    let span = add_otel_span_attributes(span, request);
+    add_network_attributes(span, request)
+}
+
+fn remote_prover_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+    let method = request.uri().path().rsplit('/').next().unwrap_or("Unknown");
+    let span = if method == "Prove" {
+        rpc_span!("remote-prover.rpc", "Prove")
+    } else {
+        rpc_span!("remote-prover.rpc", "Unknown")
+    };
+
+    let span = add_otel_span_attributes(span, request);
+    add_network_attributes(span, request)
+}
+
+fn remote_prover_proxy_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
+    let method = request.uri().path().rsplit('/').next().unwrap_or("Unknown");
+    let span = if method == "Status" {
+        rpc_span!("remote-prover-proxy.rpc", "Status")
+    } else {
+        rpc_span!("remote-prover-proxy.rpc", "Unknown")
     };
 
     let span = add_otel_span_attributes(span, request);


### PR DESCRIPTION
## Context

Closes #1060.

All of our components run an Otel trace layer on their tonic stack.

Some components are missing these layers.

## Changes
- Add trace layers to remote prover and proxy tonic servers.
- Refactor the traced span fns in `tracing/grpc.rs` so that the explanatory comment is not duplicated.