### PR TITLE
fix: remove trailing semi-colon, make installing non-failing

### DIFF
--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -10,15 +10,17 @@ pub fn enable_logging(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let stmts = function.block.stmts;
     let block: Block = parse_quote! {{
         if ::std::env::args().any(|e| e == "--nocapture") {
-            ::miden_node_utils::logging::setup_tracing(
+            if let Err(err) = ::miden_node_utils::logging::setup_tracing(
                 ::miden_node_utils::logging::OpenTelemetry::Disabled
-            ).expect("logging setup should succeed");
+            ) {
+                eprintln!("failed to setup tracing for tests using `enable_logging` proc-macro");
+            }
             let span = ::tracing::span!(::tracing::Level::INFO, #name).entered();
 
             #(#stmts)*
         } else {
             #(#stmts)*
-        };
+        }
     }};
     function.block = Box::new(block);
 


### PR DESCRIPTION
The proc-macro produces a trailing semicolon after expanding the statements of the tagged test function, i.e.

```
fn foo() -> Result<(),()> {
Ok(())
}
```

would become 

```
fn foo() -> Result<(),()> {
Ok(());
```

which would fail to compile.

---

Part two of the PR is only printing an error to `stderr` if the tracing setup fails rather than exiting and failing test cases.