### PR TITLE
fix: release automation config fix

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -4,15 +4,3 @@ release_always   = true  # Without the tracking PR, it would never trigger unles
 
 git_release_enable = false
 git_tag_enable     = false
-
-[[package]]
-name = "miden-remote-prover"
-# Unpublished as of yet.
-# TODO: remove once the first version of miden-remote-prover is on crates.io.
-semver_check = false
-
-[[package]]
-name = "miden-remote-prover-client"
-# Unpublished as of yet.
-# TODO: remove once the first version of miden-remote-prover-client is on crates.io.
-semver_check = false

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -9,10 +9,10 @@ git_tag_enable     = false
 name = "miden-remote-prover"
 # Unpublished as of yet.
 # TODO: remove once the first version of miden-remote-prover is on crates.io.
-semver_checks = false
+semver_check = false
 
 [[package]]
 name = "miden-remote-prover-client"
 # Unpublished as of yet.
 # TODO: remove once the first version of miden-remote-prover-client is on crates.io.
-semver_checks = false
+semver_check = false


### PR DESCRIPTION
The root cause was a wrong key [`semver_checks` instead of `semver_check`](https://github.com/0xMiden/miden-node/commit/8061fe1e1969eed267e5b1c979e76499994d7de9), but release-plz's error was misleading as `config file not found` (which I now [PRed a fix for](https://github.com/release-plz/release-plz/pull/2311)).

But actually I realized, this was only there because those two crates hadn't been released before at that point. Since they're now on crates.io, [we can remove this config value altogether](https://github.com/0xMiden/miden-node/commit/32e40dc35bcd57f486d804105fdd0731ab1ca455).

This should now work ™️ 