### PR TITLE
feat(block-producer): increase and make max txs per batch and batches per block configurable via CLI

### DIFF
--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -50,13 +50,13 @@ impl BlockProducerCommand {
             url.to_socket().context("Failed to extract socket address from store URL")?;
 
         // Runtime validation for protocol constraints
-        if block_producer.max_batches_per_block >= miden_objects::MAX_BATCHES_PER_BLOCK {
+        if block_producer.max_batches_per_block > miden_objects::MAX_BATCHES_PER_BLOCK {
             anyhow::bail!(
                 "max-batches-per-block cannot exceed protocol limit of {}",
                 miden_objects::MAX_BATCHES_PER_BLOCK
             );
         }
-        if block_producer.max_txs_per_batch >= miden_objects::MAX_ACCOUNTS_PER_BATCH {
+        if block_producer.max_txs_per_batch > miden_objects::MAX_ACCOUNTS_PER_BATCH {
             anyhow::bail!(
                 "max-txs-per-batch cannot exceed protocol limit of {}",
                 miden_objects::MAX_ACCOUNTS_PER_BATCH
@@ -126,8 +126,9 @@ mod tests {
                 block_prover_url: None,
                 block_interval: std::time::Duration::from_secs(1),
                 batch_interval: std::time::Duration::from_secs(1),
-                max_txs_per_batch: miden_objects::MAX_ACCOUNTS_PER_BATCH, /* Use protocol limit
-                                                                           * (should fail) */
+                max_txs_per_batch: miden_objects::MAX_ACCOUNTS_PER_BATCH + 1, /* Use protocol
+                                                                               * limit
+                                                                               * (should fail) */
                 max_batches_per_block: 8,
             },
             enable_otel: false,

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use miden_node_block_producer::{SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH};
+use miden_node_block_producer::{DEFAULT_MAX_BATCHES_PER_BLOCK, DEFAULT_MAX_TXS_PER_BATCH};
 use url::Url;
 
 pub mod block_producer;
@@ -19,6 +19,8 @@ const ENV_STORE_BLOCK_PRODUCER_URL: &str = "MIDEN_NODE_STORE_BLOCK_PRODUCER_URL"
 const ENV_DATA_DIRECTORY: &str = "MIDEN_NODE_DATA_DIRECTORY";
 const ENV_ENABLE_OTEL: &str = "MIDEN_NODE_ENABLE_OTEL";
 const ENV_GENESIS_CONFIG_FILE: &str = "MIDEN_GENESIS_CONFIG_FILE";
+const ENV_MAX_TXS_PER_BATCH: &str = "MIDEN_MAX_TXS_PER_BATCH";
+const ENV_MAX_BATCHES_PER_BLOCK: &str = "MIDEN_MAX_BATCHES_PER_BLOCK";
 
 const DEFAULT_BLOCK_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_BATCH_INTERVAL: Duration = Duration::from_secs(2);
@@ -83,10 +85,10 @@ pub struct BlockProducerConfig {
     pub block_prover_url: Option<Url>,
 
     /// The number of transactions per batch.
-    #[arg(long = "max-txs-per-batch", default_value_t = SERVER_MAX_TXS_PER_BATCH)]
-    max_txs_per_batch: usize,
+    #[arg(long = "max-txs-per-batch", env = ENV_MAX_TXS_PER_BATCH, value_name = "NUM", default_value_t = DEFAULT_MAX_TXS_PER_BATCH)]
+    pub max_txs_per_batch: usize,
 
     /// Maximum number of batches per block.
-    #[arg(long = "max-batches-per-block", default_value_t = SERVER_MAX_BATCHES_PER_BLOCK)]
-    max_batches_per_block: usize,
+    #[arg(long = "max-batches-per-block", env = ENV_MAX_BATCHES_PER_BLOCK, value_name = "NUM", default_value_t = DEFAULT_MAX_BATCHES_PER_BLOCK)]
+    pub max_batches_per_block: usize,
 }

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -25,10 +25,10 @@ pub use server::BlockProducer;
 pub const COMPONENT: &str = "miden-block-producer";
 
 /// The number of transactions per batch.
-pub const SERVER_MAX_TXS_PER_BATCH: usize = 8;
+pub const DEFAULT_MAX_TXS_PER_BATCH: usize = 8;
 
 /// Maximum number of batches per block.
-pub const SERVER_MAX_BATCHES_PER_BLOCK: usize = 8;
+pub const DEFAULT_MAX_BATCHES_PER_BLOCK: usize = 8;
 
 /// Size of the batch building worker pool.
 const SERVER_NUM_BATCH_BUILDERS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
@@ -46,12 +46,12 @@ const SERVER_MEMPOOL_STATE_RETENTION: usize = 5;
 const SERVER_MEMPOOL_EXPIRATION_SLACK: u32 = 2;
 
 const _: () = assert!(
-    SERVER_MAX_BATCHES_PER_BLOCK <= miden_objects::MAX_BATCHES_PER_BLOCK,
+    DEFAULT_MAX_BATCHES_PER_BLOCK <= miden_objects::MAX_BATCHES_PER_BLOCK,
     "Server constraint cannot exceed the protocol's constraint"
 );
 
 const _: () = assert!(
-    SERVER_MAX_TXS_PER_BATCH <= miden_objects::MAX_ACCOUNTS_PER_BATCH,
+    DEFAULT_MAX_TXS_PER_BATCH <= miden_objects::MAX_ACCOUNTS_PER_BATCH,
     "Server constraint cannot exceed the protocol's constraint"
 );
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -18,7 +18,7 @@ use transaction_expiration::TransactionExpirations;
 use transaction_graph::TransactionGraph;
 
 use crate::{
-    COMPONENT, SERVER_MAX_BATCHES_PER_BLOCK, SERVER_MAX_TXS_PER_BATCH,
+    COMPONENT, DEFAULT_MAX_BATCHES_PER_BLOCK, DEFAULT_MAX_TXS_PER_BATCH,
     domain::transaction::AuthenticatedTransaction, errors::AddTransactionError,
 };
 
@@ -66,7 +66,7 @@ enum BudgetStatus {
 impl Default for BatchBudget {
     fn default() -> Self {
         Self {
-            transactions: SERVER_MAX_TXS_PER_BATCH,
+            transactions: DEFAULT_MAX_TXS_PER_BATCH,
             input_notes: MAX_INPUT_NOTES_PER_BATCH,
             output_notes: MAX_OUTPUT_NOTES_PER_BATCH,
             accounts: MAX_ACCOUNTS_PER_BATCH,
@@ -76,7 +76,7 @@ impl Default for BatchBudget {
 
 impl Default for BlockBudget {
     fn default() -> Self {
-        Self { batches: SERVER_MAX_BATCHES_PER_BLOCK }
+        Self { batches: DEFAULT_MAX_BATCHES_PER_BLOCK }
     }
 }
 


### PR DESCRIPTION
- Adds CLI arguments to configure the maximum number of transactions per batch (--max-txs-per-batch) and the maximum number of batches per block (--max-batches-per-block) for both standalone and bundled node modes.
- Updates the default values to match previous behavior (8 per batch, 8 per block), but allows users to override them at runtime.