### PR TITLE
fix(ntx): accounts are never unlocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.1 (2025-07-14)
+
+### Fixes
+
+- Network accounts are disabled after one transaction (#1086).
+
 ## v0.10.0 (2025-07-10)
 
 ### Enhancements

--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -235,6 +235,9 @@ impl State {
                 },
             }
 
+            // If this account was in-progress, then it should no longer be as this update is the
+            // result of our own network transaction.
+            self.in_progress.remove(&prefix);
             tx_impact.account_delta = Some(prefix);
         }
         for note in network_notes {


### PR DESCRIPTION
I forgot to remove network accounts from the in-progress jail once the transaction completes.

I noticed this while debugging the instrumentation.

### Instrumentation

I've noticed that the ntx spans aren't actually chaining together. This is because we're spawning a task and not passing along the span.

This PR addresses this (I think) - its difficult to be sure because I can't trigger ntx using client integration tests at the moment.

I've added a call to the outer blocking spawn, and the inner spawn so I assume this should work.