### PR TITLE
chore: handle proxy status requests in regular pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,6 +2662,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap 4.5.41",
+ "http 1.3.1",
  "humantime",
  "miden-block-prover",
  "miden-lib",

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -28,6 +28,7 @@ async-trait           = { version = "0.1" }
 axum                  = { version = "0.8" }
 bytes                 = { version = "1.0" }
 clap                  = { features = ["derive", "env"], version = "4.5" }
+http                  = { version = "1.0" }
 humantime             = { workspace = true }
 miden-block-prover    = { workspace = true }
 miden-lib             = { workspace = true }

--- a/bin/remote-prover/src/utils.rs
+++ b/bin/remote-prover/src/utils.rs
@@ -1,13 +1,78 @@
 use std::net::TcpListener;
 
-use miden_remote_prover::error::RemoteProverError;
+use http::HeaderMap;
+use miden_remote_prover::{
+    error::RemoteProverError,
+    generated::remote_prover::{ProxyStatusResponse, WorkerStatus},
+};
 use pingora::{Error, ErrorType, http::ResponseHeader, protocols::http::ServerSession};
 use pingora_proxy::Session;
+use prost::Message;
 use tracing::debug;
 
-use crate::{COMPONENT, commands::PROXY_HOST, proxy::metrics::QUEUE_DROP_COUNT};
+use crate::{
+    COMPONENT,
+    commands::PROXY_HOST,
+    proxy::{LoadBalancerState, metrics::QUEUE_DROP_COUNT},
+};
 
 const RESOURCE_EXHAUSTED_CODE: u16 = 8;
+
+/// Create a gRPC proxy status response
+///
+/// This creates a proper gRPC response with the `ProxyStatusResponse` serialized as protobuf
+pub async fn create_proxy_status_response(
+    session: &mut Session,
+    load_balancer_state: &LoadBalancerState,
+) -> pingora_core::Result<bool> {
+    // Build the proxy status response
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let supported_proof_type: i32 = load_balancer_state.supported_proof_type().into();
+
+    let workers = load_balancer_state.workers().await;
+    let worker_statuses: Vec<WorkerStatus> = workers.iter().map(WorkerStatus::from).collect();
+
+    let status_response = ProxyStatusResponse {
+        version,
+        supported_proof_type,
+        workers: worker_statuses,
+    };
+
+    // Serialize the protobuf message
+    let mut response_body = Vec::new();
+    status_response.encode(&mut response_body).map_err(|e| {
+        Error::new(ErrorType::InternalError)
+            .more_context(format!("Failed to encode proto response: {e}"))
+    })?;
+
+    let mut grpc_message = Vec::new();
+
+    // Add compression flag (1 byte, 0 = no compression)
+    grpc_message.push(0u8);
+
+    // Add message length (4 bytes, big-endian)
+    let msg_len = response_body.len() as u32;
+    grpc_message.extend_from_slice(&msg_len.to_be_bytes());
+
+    // Add the actual message
+    grpc_message.extend_from_slice(&response_body);
+
+    // Create gRPC response headers WITHOUT grpc-status (that goes in trailers)
+    let mut header = ResponseHeader::build(200, None)?;
+    header.insert_header("content-type", "application/grpc".to_string())?;
+    // Don't set grpc-status here - it must be in trailers for proper gRPC
+
+    session.set_keepalive(None);
+    session.write_response_header(Box::new(header), false).await?;
+    session.write_response_body(Some(grpc_message.into()), false).await?;
+
+    // Send trailers with gRPC status
+    let mut trailers = HeaderMap::new();
+    trailers.insert("grpc-status", "0".parse().map_err(|_| Error::new(ErrorType::InternalError))?);
+    session.write_response_trailers(trailers).await?;
+
+    Ok(true)
+}
 
 /// Create a 503 response for a full queue
 pub(crate) async fn create_queue_full_response(


### PR DESCRIPTION
@bobbinth @sergerad this is an example of how the status endpoint could be embedded in the regular request pipeline. The downside of this is that we need to generate a gRPC response by hand. It does not add much overhead IMO.

If we decide to go down this path, I can bring here the proxy status cache from the status service and remove the service itself.

part of #1082 