### PR TITLE
chore: update miden-base to latest rev `d6dc69b8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2170,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5453d77fc1a7e4642e1fd8855e1d5904087ac1ec53b02549a11af4697df2713"
+checksum = "fd3ed10cf5894fea966161ef42e5a366779ff2ae5ea35fd45e12236115083851"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#f9d5257d432e83a3e164791eb4fdd6b49dd09a63"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2214,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dee966d664e92903bd9d20e846179395c50941e608c975970c20c034a32ab64"
+checksum = "d432f414f3029470619f41f741c67551d14e282dd0ad19cd276b14eeefdd34b6"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#f9d5257d432e83a3e164791eb4fdd6b49dd09a63"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#f9d5257d432e83a3e164791eb4fdd6b49dd09a63"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2625,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fe7dd289f73562936b6810ed370d64e78129926c7f0f20860f8d263dfcb566"
+checksum = "ec8e112548b2d316598c2258326b5f8d8d018f37df8a190d2cd7f9d2e11a4921"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2641,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ae8ccd743e679dccca400cb748eedc3d26c3ebd93a9ea6cb47ef50ed0555eb"
+checksum = "79553c02f2e1de9c1d5a0f956a609f12c99b9590d31787fb0c5b865018290412"
 dependencies = [
  "miden-air",
  "miden-debug-types",
@@ -2719,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d090c8a83966282b5fcd96bc2c9c1b1f5f7569c6b85a086ff693b12213990"
+checksum = "1a124c7b77b395ca04a94b3d4a2bae04bfc422831e364279743395fb7b95e70f"
 dependencies = [
  "env_logger",
  "miden-assembly",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#f9d5257d432e83a3e164791eb4fdd6b49dd09a63"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#f9d5257d432e83a3e164791eb4fdd6b49dd09a63"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.11.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#f9d5257d432e83a3e164791eb4fdd6b49dd09a63"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#d6dc69b877f2ccbed55e6faedc0ca1e9672a9f7c"
 dependencies = [
  "miden-objects",
  "miden-tx",
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1771d84e358da9957786a7058b7431e2d5d5934e37de128b927b9e520ec0d2e"
+checksum = "6d5fb22ce7af59baae7dafe3c68ddaacb738108d3bb5ecb6738088daa87be825"
 dependencies = [
  "lock_api",
  "loom",
@@ -2800,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253fb17aee78a1d9b0d2030fc1a14e7559590a43a7d2d00e7cce0bd23f61fbb6"
+checksum = "c4995ea8f48bf30ec02cec53019d1345c5c7cb0655290459e3e750295df95fa3"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -4178,7 +4178,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4191,7 +4191,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4752,7 +4752,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5754,7 +5754,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/ntx-builder/src/transaction.rs
+++ b/crates/ntx-builder/src/transaction.rs
@@ -16,7 +16,7 @@ use miden_remote_prover_client::remote_prover::tx_prover::RemoteTransactionProve
 use miden_tx::{
     DataStore, DataStoreError, LocalTransactionProver, MastForestStore, NoteAccountExecution,
     NoteConsumptionChecker, TransactionExecutor, TransactionExecutorError, TransactionMastStore,
-    TransactionProverError,
+    TransactionProverError, auth::UnreachableAuth,
 };
 use rand::seq::SliceRandom;
 use tokio::task::JoinError;
@@ -125,7 +125,8 @@ impl NtxContext {
         data_store: &NtxDataStore,
         notes: InputNotes<InputNote>,
     ) -> NtxResult<InputNotes<InputNote>> {
-        let executor = TransactionExecutor::new(data_store, None);
+        let executor: TransactionExecutor<'_, '_, _, UnreachableAuth> =
+            TransactionExecutor::new(data_store, None);
         let checker = NoteConsumptionChecker::new(&executor);
 
         let notes = match checker
@@ -170,7 +171,8 @@ impl NtxContext {
         data_store: &NtxDataStore,
         notes: InputNotes<InputNote>,
     ) -> NtxResult<ExecutedTransaction> {
-        let executor = TransactionExecutor::new(data_store, None);
+        let executor: TransactionExecutor<'_, '_, _, UnreachableAuth> =
+            TransactionExecutor::new(data_store, None);
 
         executor
             .execute_transaction(


### PR DESCRIPTION
Migrations:
- `TransactionExecutor` uses generics instead of `dyn Trait`
    - miden-base reference: https://github.com/0xMiden/miden-base/pull/1580
    - commit: 8fe85f2c82219b16d65df499caf262e2004ccc9b