### PR TITLE
chore: Update default genesis max token supply

### DIFF
--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -56,7 +56,7 @@ impl Default for GenesisConfig {
             .expect("Timestamp should fit into u32"),
             wallet: vec![],
             fungible_faucet: vec![FungibleFaucetConfig {
-                max_supply: 100_000_000_000u64,
+                max_supply: 100_000_000_000_000_000u64,
                 decimals: 6u8,
                 storage_mode: StorageMode::Public,
                 symbol: "MIDEN".to_owned(),


### PR DESCRIPTION
## Context

The default max supply is small enough to get burned through via faucet in a few days / weeks despite rate limiting.

## Changes

Update default max token supply from 100e9 to 100e15.