### PR TITLE
store: deduplicate code blobs stored in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [BREAKING] Updated MSRV to 1.88.
 - [BREAKING] Refactor protobuf messages ([#1045](https://github.com/0xMiden/miden-node/pull/#1045)).
+- [BREAKING] De-duplicate storage of code in DB (no-migration) ([#1083](https://github.com/0xMiden/miden-node/issue/#1083)).
 
 ### Enhancements
 

--- a/crates/store/src/db/migrations/2025062000000_setup/up.sql
+++ b/crates/store/src/db/migrations/2025062000000_setup/up.sql
@@ -6,16 +6,31 @@ CREATE TABLE block_headers (
     CONSTRAINT block_header_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF)
 );
 
+CREATE TABLE account_codes (
+    code_commitment BLOB NOT NULL,
+    code            BLOB NOT NULL,
+    PRIMARY KEY(code_commitment)
+) WITHOUT ROWID;
 
 CREATE TABLE accounts (
     account_id                              BLOB NOT NULL,
     network_account_id_prefix               INTEGER NULL, -- 30-bit account ID prefix, only filled for network accounts
     account_commitment                      BLOB NOT NULL,
     block_num                               INTEGER NOT NULL,
-    details                                 BLOB,
+    code_commitment                         BLOB,
+    storage                                 BLOB,
+    vault                                   BLOB,
+    nonce                                   INTEGER,
 
     PRIMARY KEY (account_id),
-    FOREIGN KEY (block_num) REFERENCES block_headers(block_num)
+    FOREIGN KEY (block_num) REFERENCES block_headers(block_num),
+    FOREIGN KEY (code_commitment) REFERENCES account_codes(code_commitment),
+    CONSTRAINT all_null_or_none_null CHECK
+        (
+            (code_commitment IS NOT NULL AND storage IS NOT NULL AND vault IS NOT NULL AND nonce IS NOT NULL)
+            OR
+            (code_commitment IS NULL AND storage IS NULL AND vault IS NULL AND nonce IS NULL)
+        )
 ) WITHOUT ROWID;
 
 CREATE INDEX idx_accounts_network_prefix ON accounts(network_account_id_prefix) WHERE network_account_id_prefix IS NOT NULL;

--- a/crates/store/src/db/migrations/2025062000000_setup/up.sql
+++ b/crates/store/src/db/migrations/2025062000000_setup/up.sql
@@ -15,8 +15,8 @@ CREATE TABLE account_codes (
 CREATE TABLE accounts (
     account_id                              BLOB NOT NULL,
     network_account_id_prefix               INTEGER NULL, -- 30-bit account ID prefix, only filled for network accounts
-    account_commitment                      BLOB NOT NULL,
     block_num                               INTEGER NOT NULL,
+    account_commitment                      BLOB NOT NULL,
     code_commitment                         BLOB,
     storage                                 BLOB,
     vault                                   BLOB,

--- a/crates/store/src/db/models/mod.rs
+++ b/crates/store/src/db/models/mod.rs
@@ -23,18 +23,7 @@ use std::num::NonZeroUsize;
 use diesel::{prelude::*, sqlite::Sqlite};
 
 use crate::{
-    db::{
-        NoteRecord, NoteSyncRecord, NullifierInfo,
-        schema::{
-            // the list of tables
-            // referenced in `#[diesel(table_name = _)]`
-            accounts,
-            block_headers,
-            notes,
-            nullifiers,
-            transactions,
-        },
-    },
+    db::{NoteRecord, NoteSyncRecord, NullifierInfo},
     errors::DatabaseError,
 };
 

--- a/crates/store/src/db/models/queries.rs
+++ b/crates/store/src/db/models/queries.rs
@@ -41,15 +41,15 @@ use crate::{
         NoteRecord, NoteSyncRecord, NoteSyncUpdate, NullifierInfo, Page, StateSyncUpdate,
         TransactionSummary,
         models::{
-            AccountRaw, AccountSummaryRaw, BigIntSum, ExpressionMethods, NoteInsertRowRaw,
-            NoteRecordRaw, NoteRecordWithScriptRaw, TransactionSummaryRaw,
+            AccountCodeRowInsert, AccountRaw, AccountRowInsert, AccountSummaryRaw,
+            AccountWithCodeRaw, BigIntSum, ExpressionMethods, NoteInsertRowRaw, NoteRecordRaw,
+            NoteRecordWithScriptRaw, TransactionSummaryRaw,
             conv::{
                 SqlTypeConvert, fungible_delta_to_raw_sql, nonce_to_raw_sql,
                 nullifier_prefix_to_raw_sql, raw_sql_to_idx, raw_sql_to_nonce, raw_sql_to_slot,
                 slot_to_raw_sql,
             },
-            deserialize_raw_vec, get_nullifier_prefix, serialize_vec, sql_sum_into,
-            vec_raw_try_into,
+            get_nullifier_prefix, serialize_vec, sql_sum_into, vec_raw_try_into,
         },
         schema,
     },
@@ -481,11 +481,20 @@ pub(crate) fn upsert_accounts(
         account_id: AccountId,
     ) -> Result<Vec<Account>, DatabaseError> {
         let account_id = account_id.to_bytes();
-        let account_details_serialized =
-            SelectDsl::select(schema::accounts::table, schema::accounts::details.assume_not_null())
-                .filter(schema::accounts::account_id.eq(account_id))
-                .get_results::<Vec<u8>>(conn)?;
-        let accounts = deserialize_raw_vec::<_, Account>(account_details_serialized)?;
+        let accounts =
+            SelectDsl::select(
+                schema::accounts::table.left_join(schema::account_codes::table.on(
+                    schema::accounts::code_commitment.eq(schema::account_codes::code_commitment),
+                )),
+                (AccountRaw::as_select(), schema::account_codes::code.nullable()),
+            )
+            .filter(schema::accounts::account_id.eq(account_id))
+            .get_results::<(AccountRaw, Option<Vec<u8>>)>(conn)?;
+
+        let accounts = Result::from_iter(accounts.into_iter().filter_map(|x| {
+            let account_with_code = AccountWithCodeRaw::from(x);
+            account_with_code.try_into().transpose()
+        }))?;
         Ok(accounts)
     }
 
@@ -528,20 +537,38 @@ pub(crate) fn upsert_accounts(
             },
         };
 
-        let val = (
-            schema::accounts::account_id.eq(account_id.to_bytes()),
-            schema::accounts::network_account_id_prefix
-                .eq(network_account_id_prefix.map(SqlTypeConvert::to_raw_sql)),
-            schema::accounts::account_commitment.eq(update.final_state_commitment().to_bytes()),
-            schema::accounts::block_num.eq(block_num.to_raw_sql()),
-            schema::accounts::details.eq(full_account.as_ref().map(|account| account.to_bytes())),
-        );
-        let v = val.clone();
+        if let Some(code) = full_account.as_ref().map(|account| account.code()) {
+            let code_value = AccountCodeRowInsert {
+                code_commitment: code.commitment().to_bytes(),
+                code: code.to_bytes(),
+            };
+            diesel::insert_into(schema::account_codes::table)
+                .values(&code_value)
+                .on_conflict(schema::account_codes::code_commitment)
+                .do_nothing()
+                .execute(conn)?;
+        }
+
+        let account_value = AccountRowInsert {
+            account_id: account_id.to_bytes(),
+            network_account_id_prefix: network_account_id_prefix
+                .map(NetworkAccountPrefix::to_raw_sql),
+            account_commitment: update.final_state_commitment().to_bytes(),
+            block_num: block_num.to_raw_sql(),
+            nonce: full_account.as_ref().map(|account| nonce_to_raw_sql(account.nonce())),
+            storage: full_account.as_ref().map(|account| account.storage().to_bytes()),
+            vault: full_account.as_ref().map(|account| account.vault().to_bytes()),
+            code_commitment: full_account
+                .as_ref()
+                .map(|account| account.code().commitment().to_bytes()),
+        };
+
+        let v = account_value.clone();
         let inserted = diesel::insert_into(schema::accounts::table)
             .values(&v)
             .on_conflict(schema::accounts::account_id)
             .do_update()
-            .set(val)
+            .set(account_value)
             .execute(conn)?;
 
         debug_assert_eq!(inserted, 1);
@@ -831,12 +858,19 @@ pub(crate) fn select_account(
     // WHERE
     //     account_id = ?1;
     //
-    let info = SelectDsl::select(schema::accounts::table, AccountRaw::as_select())
-        .filter(schema::accounts::account_id.eq(account_id.to_bytes()))
-        .get_result::<models::AccountRaw>(conn)
-        .optional()?
-        .ok_or(DatabaseError::AccountNotFoundInDb(account_id))?;
-    let info = info.try_into()?;
+
+    let raw = SelectDsl::select(
+        schema::accounts::table.left_join(
+            schema::account_codes::table
+                .on(schema::accounts::code_commitment.eq(schema::account_codes::code_commitment)),
+        ),
+        (AccountRaw::as_select(), schema::account_codes::code.nullable()),
+    )
+    .filter(schema::accounts::account_id.eq(account_id.to_bytes()))
+    .get_result::<(AccountRaw, Option<Vec<u8>>)>(conn)
+    .optional()?
+    .ok_or(DatabaseError::AccountNotFoundInDb(account_id))?;
+    let info: AccountInfo = AccountWithCodeRaw::from(raw).try_into()?;
     Ok(info)
 }
 
@@ -862,14 +896,22 @@ pub(crate) fn select_account_by_id_prefix(
     //     accounts
     // WHERE
     //     network_account_id_prefix = ?1;
-    let maybe_info = SelectDsl::select(schema::accounts::table, AccountRaw::as_select())
-        .filter(schema::accounts::network_account_id_prefix.eq(Some(i64::from(id_prefix))))
-        .get_result::<AccountRaw>(conn)
-        .optional()
-        .map_err(DatabaseError::Diesel)?;
+    let maybe_info = SelectDsl::select(
+        schema::accounts::table.left_join(
+            schema::account_codes::table
+                .on(schema::account_codes::code_commitment.eq(schema::accounts::code_commitment)),
+        ),
+        (AccountRaw::as_select(), schema::account_codes::code.nullable()),
+    )
+    .filter(schema::accounts::network_account_id_prefix.eq(Some(i64::from(id_prefix))))
+    .get_result::<(AccountRaw, Option<Vec<u8>>)>(conn)
+    .optional()
+    .map_err(DatabaseError::Diesel)?;
 
-    let result: Result<Option<AccountInfo>, DatabaseError> =
-        maybe_info.map(std::convert::TryInto::<AccountInfo>::try_into).transpose();
+    let result: Result<Option<AccountInfo>, DatabaseError> = maybe_info
+        .map(AccountWithCodeRaw::from)
+        .map(std::convert::TryInto::<AccountInfo>::try_into)
+        .transpose();
 
     result
 }
@@ -1110,9 +1152,19 @@ pub(crate) fn select_all_accounts(
     //     accounts
     // ORDER BY
     //     block_num ASC;
-    let accounts_raw =
-        QueryDsl::select(schema::accounts::table, models::AccountRaw::as_select()).load(conn)?;
-    vec_raw_try_into(accounts_raw)
+
+    let accounts_raw = QueryDsl::select(
+        schema::accounts::table.left_join(
+            schema::account_codes::table
+                .on(schema::accounts::code_commitment.eq(schema::account_codes::code_commitment)),
+        ),
+        (models::AccountRaw::as_select(), schema::account_codes::code.nullable()),
+    )
+    .load::<(AccountRaw, Option<Vec<u8>>)>(conn)?;
+    let account_infos = vec_raw_try_into::<AccountInfo, AccountWithCodeRaw>(
+        accounts_raw.into_iter().map(AccountWithCodeRaw::from),
+    )?;
+    Ok(account_infos)
 }
 
 pub(crate) fn select_accounts_by_id(
@@ -1123,12 +1175,19 @@ pub(crate) fn select_accounts_by_id(
 
     let account_ids = account_ids.iter().map(|account_id| account_id.to_bytes().clone());
 
-    let accounts_raw = QueryDsl::filter(
-        QueryDsl::select(schema::accounts::table, models::AccountRaw::as_select()),
-        schema::accounts::account_id.eq_any(account_ids),
+    let accounts_raw = SelectDsl::select(
+        schema::accounts::table.left_join(
+            schema::account_codes::table
+                .on(schema::accounts::code_commitment.eq(schema::account_codes::code_commitment)),
+        ),
+        (AccountRaw::as_select(), schema::account_codes::code.nullable()),
     )
-    .load(conn)?;
-    vec_raw_try_into(accounts_raw)
+    .filter(schema::accounts::account_id.eq_any(account_ids))
+    .load::<(AccountRaw, Option<Vec<u8>>)>(conn)?;
+    let account_infos = vec_raw_try_into::<AccountInfo, AccountWithCodeRaw>(
+        accounts_raw.into_iter().map(AccountWithCodeRaw::from),
+    )?;
+    Ok(account_infos)
 }
 
 /// Selects and merges account deltas by account id and block range from the DB using the given

--- a/crates/store/src/db/models/types.rs
+++ b/crates/store/src/db/models/types.rs
@@ -510,10 +510,10 @@ pub(crate) struct AccountCodeRowInsert {
 pub(crate) struct AccountRowInsert {
     pub(crate) account_id: Vec<u8>,
     pub(crate) network_account_id_prefix: Option<i64>,
-    pub(crate) account_commitment: Vec<u8>,
     pub(crate) block_num: i64,
-    pub(crate) nonce: Option<i64>,
+    pub(crate) account_commitment: Vec<u8>,
+    pub(crate) code_commitment: Option<Vec<u8>>,
     pub(crate) storage: Option<Vec<u8>>,
     pub(crate) vault: Option<Vec<u8>>,
-    pub(crate) code_commitment: Option<Vec<u8>>,
+    pub(crate) nonce: Option<i64>,
 }

--- a/crates/store/src/db/models/types.rs
+++ b/crates/store/src/db/models/types.rs
@@ -1,10 +1,11 @@
 use bigdecimal::BigDecimal;
-use diesel::prelude::Insertable;
+use diesel::prelude::{AsChangeset, Insertable};
 use miden_lib::utils::{Deserializable, Serializable};
 use miden_node_proto::{self as proto, domain::account::AccountSummary};
 use miden_objects::{
     Felt, Word,
-    account::{Account, AccountId},
+    account::{Account, AccountCode, AccountId, AccountStorage},
+    asset::AssetVault,
     block::{BlockHeader, BlockNoteIndex, BlockNumber},
     crypto::merkle::SparseMerklePath,
     note::{
@@ -16,42 +17,83 @@ use miden_objects::{
 
 use super::{
     DatabaseError, NoteRecord, NoteSyncRecord, NullifierInfo, Queryable, QueryableByName,
-    Selectable, Sqlite, accounts, block_headers, notes, nullifiers, transactions,
+    Selectable, Sqlite,
 };
-use crate::db::models::conv::{
-    SqlTypeConvert, aux_to_raw_sql, execution_hint_to_raw_sql, execution_mode_to_raw_sql,
-    idx_to_raw_sql, note_type_to_raw_sql,
+use crate::db::{
+    models::conv::{
+        SqlTypeConvert, aux_to_raw_sql, execution_hint_to_raw_sql, execution_mode_to_raw_sql,
+        idx_to_raw_sql, note_type_to_raw_sql, raw_sql_to_nonce,
+    },
+    schema,
 };
 
 #[derive(Debug, Clone, Queryable, QueryableByName, Selectable)]
-#[diesel(table_name = accounts)]
+#[diesel(table_name = schema::accounts)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct AccountRaw {
     pub account_id: Vec<u8>,
     pub account_commitment: Vec<u8>,
     pub block_num: i64,
-    pub details: Option<Vec<u8>>,
+    pub storage: Option<Vec<u8>>,
+    pub vault: Option<Vec<u8>>,
+    pub nonce: Option<i64>,
 }
 
-impl TryInto<proto::domain::account::AccountInfo> for AccountRaw {
+#[derive(Debug, Clone, QueryableByName)]
+pub struct AccountWithCodeRaw {
+    #[diesel(embed)]
+    pub account: AccountRaw,
+    #[diesel(embed)]
+    pub code: Option<Vec<u8>>,
+}
+
+impl From<(AccountRaw, Option<Vec<u8>>)> for AccountWithCodeRaw {
+    fn from((account, code): (AccountRaw, Option<Vec<u8>>)) -> Self {
+        Self { account, code }
+    }
+}
+
+impl TryInto<proto::domain::account::AccountInfo> for AccountWithCodeRaw {
     type Error = DatabaseError;
     fn try_into(self) -> Result<proto::domain::account::AccountInfo, Self::Error> {
         use proto::domain::account::{AccountInfo, AccountSummary};
-        let account_id = AccountId::read_from_bytes(&self.account_id[..])?;
-        let account_commitment = Word::read_from_bytes(&self.account_commitment[..])?;
-        let block_num = BlockNumber::from_raw_sql(self.block_num)?;
+        let account_id = AccountId::read_from_bytes(&self.account.account_id[..])?;
+        let account_commitment = Word::read_from_bytes(&self.account.account_commitment[..])?;
+        let block_num = BlockNumber::from_raw_sql(self.account.block_num)?;
         let summary = AccountSummary {
             account_id,
             account_commitment,
             block_num,
         };
-        let details = self.details.as_deref().map(Account::read_from_bytes).transpose()?;
-        Ok(AccountInfo { summary, details })
+        let maybe_account = self.try_into()?;
+        Ok(AccountInfo { summary, details: maybe_account })
+    }
+}
+
+impl TryInto<Option<Account>> for AccountWithCodeRaw {
+    type Error = DatabaseError;
+    fn try_into(self) -> Result<Option<Account>, Self::Error> {
+        let account_id = AccountId::read_from_bytes(&self.account.account_id[..])?;
+
+        let details = if let (Some(vault), Some(storage), Some(nonce), Some(code)) =
+            (self.account.vault, self.account.storage, self.account.nonce, self.code)
+        {
+            let vault = AssetVault::read_from_bytes(&vault)?;
+            let storage = AccountStorage::read_from_bytes(&storage)?;
+            let code = AccountCode::read_from_bytes(&code)?;
+            let nonce = raw_sql_to_nonce(nonce);
+            let nonce = Felt::new(nonce);
+            Some(Account::from_parts(account_id, vault, storage, code, nonce))
+        } else {
+            // a private account
+            None
+        };
+        Ok(details)
     }
 }
 
 #[derive(Debug, Clone, Queryable, QueryableByName, Selectable)]
-#[diesel(table_name = nullifiers)]
+#[diesel(table_name = schema::nullifiers)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct NullifierWithoutPrefixRawRow {
     pub nullifier: Vec<u8>,
@@ -68,7 +110,7 @@ impl TryInto<NullifierInfo> for NullifierWithoutPrefixRawRow {
 }
 
 #[derive(Debug, Clone, Queryable, QueryableByName, Selectable)]
-#[diesel(table_name = block_headers)]
+#[diesel(table_name = schema::block_headers)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct BlockHeaderRaw {
     #[allow(dead_code)]
@@ -84,7 +126,7 @@ impl TryInto<BlockHeader> for BlockHeaderRaw {
 }
 
 #[derive(Debug, Clone, PartialEq, Queryable, Selectable, QueryableByName)]
-#[diesel(table_name = transactions)]
+#[diesel(table_name = schema::transactions)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct TransactionSummaryRaw {
     account_id: Vec<u8>,
@@ -104,7 +146,7 @@ impl TryInto<crate::db::TransactionSummary> for TransactionSummaryRaw {
 }
 
 #[derive(Debug, Clone, PartialEq, Selectable, Queryable, QueryableByName)]
-#[diesel(table_name = notes)]
+#[diesel(table_name = schema::notes)]
 #[diesel(check_for_backend(Sqlite))]
 pub struct NoteMetadataRaw {
     note_type: i32,
@@ -130,7 +172,7 @@ impl TryInto<NoteMetadata> for NoteMetadataRaw {
 }
 
 #[derive(Debug, Clone, PartialEq, Selectable, Queryable, QueryableByName)]
-#[diesel(table_name = notes)]
+#[diesel(table_name = schema::notes)]
 #[diesel(check_for_backend(Sqlite))]
 pub struct BlockNoteIndexRaw {
     pub batch_index: i32,
@@ -151,7 +193,7 @@ impl TryInto<BlockNoteIndex> for BlockNoteIndexRaw {
 }
 
 #[derive(Debug, Clone, PartialEq, Selectable, Queryable, QueryableByName)]
-#[diesel(table_name = notes)]
+#[diesel(table_name = schema::notes)]
 #[diesel(check_for_backend(Sqlite))]
 pub struct NoteSyncRecordRawRow {
     pub committed_at: i64, // BlockNumber
@@ -184,7 +226,7 @@ impl TryInto<NoteSyncRecord> for NoteSyncRecordRawRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Selectable, Queryable, QueryableByName)]
-#[diesel(table_name = accounts)]
+#[diesel(table_name = schema::accounts)]
 #[diesel(check_for_backend(Sqlite))]
 pub struct AccountSummaryRaw {
     account_id: Vec<u8>,         // AccountId,
@@ -208,7 +250,7 @@ impl TryInto<AccountSummary> for AccountSummaryRaw {
 }
 
 #[derive(Debug, Clone, PartialEq, Selectable, Queryable, QueryableByName)]
-#[diesel(table_name = notes)]
+#[diesel(table_name = schema::notes)]
 #[diesel(check_for_backend(Sqlite))]
 pub struct NoteDetailsRaw {
     pub assets: Option<Vec<u8>>,
@@ -355,7 +397,7 @@ impl TryInto<NoteRecord> for NoteRecordWithScriptRaw {
 }
 
 #[derive(Debug, Clone, PartialEq, Selectable, Queryable, QueryableByName)]
-#[diesel(table_name = notes)]
+#[diesel(table_name = schema::notes)]
 #[diesel(check_for_backend(Sqlite))]
 pub struct NoteRecordRaw {
     pub committed_at: i64,
@@ -407,7 +449,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Insertable)]
-#[diesel(table_name = notes)]
+#[diesel(table_name = schema::notes)]
 pub struct NoteInsertRowRaw {
     pub committed_at: i64,
 
@@ -454,4 +496,24 @@ impl From<(NoteRecord, Option<Nullifier>)> for NoteInsertRowRaw {
             serial_num: note.details.as_ref().map(|d| d.serial_num().to_bytes()),
         }
     }
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = schema::account_codes)]
+pub(crate) struct AccountCodeRowInsert {
+    pub(crate) code_commitment: Vec<u8>,
+    pub(crate) code: Vec<u8>,
+}
+
+#[derive(Insertable, AsChangeset, Debug, Clone)]
+#[diesel(table_name = schema::accounts)]
+pub(crate) struct AccountRowInsert {
+    pub(crate) account_id: Vec<u8>,
+    pub(crate) network_account_id_prefix: Option<i64>,
+    pub(crate) account_commitment: Vec<u8>,
+    pub(crate) block_num: i64,
+    pub(crate) nonce: Option<i64>,
+    pub(crate) storage: Option<Vec<u8>>,
+    pub(crate) vault: Option<Vec<u8>>,
+    pub(crate) code_commitment: Option<Vec<u8>>,
 }

--- a/crates/store/src/db/schema.rs
+++ b/crates/store/src/db/schema.rs
@@ -50,8 +50,18 @@ diesel::table! {
         account_id -> Binary,
         network_account_id_prefix -> Nullable<BigInt>,
         account_commitment -> Binary,
+        code_commitment -> Binary, // double check if this can ever be the case, I don't think so
+        storage -> Nullable<Binary>,
+        vault -> Nullable<Binary>,
+        nonce -> Nullable<BigInt>,
         block_num -> BigInt,
-        details -> Nullable<Binary>,
+    }
+}
+
+diesel::table! {
+    account_codes (code_commitment) {
+        code_commitment -> Binary,
+        code -> Binary,
     }
 }
 
@@ -109,6 +119,7 @@ diesel::table! {
 
 diesel::joinable!(account_deltas -> accounts (account_id));
 diesel::joinable!(account_deltas -> block_headers (block_num));
+diesel::joinable!(accounts -> account_codes (code_commitment));
 diesel::joinable!(accounts -> block_headers (block_num));
 diesel::joinable!(notes -> accounts (sender));
 diesel::joinable!(notes -> block_headers (committed_at));
@@ -119,6 +130,7 @@ diesel::joinable!(transactions -> block_headers (block_num));
 
 diesel::allow_tables_to_appear_in_same_query!(
     account_deltas,
+    account_codes,
     account_fungible_asset_deltas,
     account_non_fungible_asset_updates,
     account_storage_map_updates,

--- a/crates/store/src/db/schema.rs
+++ b/crates/store/src/db/schema.rs
@@ -50,7 +50,7 @@ diesel::table! {
         account_id -> Binary,
         network_account_id_prefix -> Nullable<BigInt>,
         account_commitment -> Binary,
-        code_commitment -> Binary, // double check if this can ever be the case, I don't think so
+        code_commitment -> Nullable<Binary>,
         storage -> Nullable<Binary>,
         vault -> Nullable<Binary>,
         nonce -> Nullable<BigInt>,

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -24,6 +24,8 @@ use crate::db::{manager::ConnectionManagerError, models::conv::DatabaseTypeConve
 pub enum DatabaseError {
     // ERRORS WITH AUTOMATIC CONVERSIONS FROM NESTED ERROR TYPES
     // ---------------------------------------------------------------------------------------------
+    #[error("account is incomplete")]
+    AccountIncomplete,
     #[error("account error")]
     AccountError(#[from] AccountError),
     #[error("account delta error")]


### PR DESCRIPTION
Modifies the table

* externalizes code by code_commitement into a separate table
* expands former details into separate columns

Closes #1083

Open Issues:

* [x] cleanup some rough edges
* [x] cross check constraints on types
* [x] verify `LEFT JOIN` is the right thing, or if `INNER JOIN` might be a better fit
