### PR TITLE
refactor: queries minor cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - [BREAKING] Updated MSRV to 1.88.
 - [BREAKING] Refactor protobuf messages ([#1045](https://github.com/0xMiden/miden-node/pull/#1045)).
-- [BREAKING] Consolidate to a single async interface and drop `#[maybe_async]` usage ([#1666](https://github.com/0xMiden/miden-node/pull/#1666))
-
 ### Enhancements
 
 - Added environment variable support for batch and block size CLI arguments ([#1081](https://github.com/0xMiden/miden-node/pull/1081)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [BREAKING] Updated MSRV to 1.88.
 - [BREAKING] Refactor protobuf messages ([#1045](https://github.com/0xMiden/miden-node/pull/#1045)).
+
 ### Enhancements
 
 - Added environment variable support for batch and block size CLI arguments ([#1081](https://github.com/0xMiden/miden-node/pull/1081)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [BREAKING] Updated MSRV to 1.88.
 - [BREAKING] Refactor protobuf messages ([#1045](https://github.com/0xMiden/miden-node/pull/#1045)).
+- [BREAKING] Consolidate to a single async interface and drop `#[maybe_async]` usage ([#1666](https://github.com/0xMiden/miden-node/pull/#1666))
+
 ### Enhancements
 
 - Added environment variable support for batch and block size CLI arguments ([#1081](https://github.com/0xMiden/miden-node/pull/1081)).

--- a/crates/store/src/db/models/conv.rs
+++ b/crates/store/src/db/models/conv.rs
@@ -34,27 +34,27 @@ use miden_objects::{Felt, block::BlockNumber, note::NoteTag};
 
 #[derive(Debug, thiserror::Error)]
 #[error("failed to convert a database value to it's in memory type {0}")]
-pub struct DbReprConvError(&'static str);
+pub struct DatabaseTypeConversionError(&'static str);
 
 /// Convert from and to it's database representation and back
 ///
 /// We do not assume sanity of DB types.
-pub(crate) trait DbReprConv: Sized {
+pub(crate) trait DatabaseTypeConversion: Sized {
     type Raw: Sized;
     type Error: std::error::Error + Send + Sync + 'static;
     fn to_raw_sql(self) -> Self::Raw;
     fn from_raw_sql(_raw: Self::Raw) -> ::std::result::Result<Self, Self::Error>;
 }
 
-impl DbReprConv for BlockNumber {
+impl DatabaseTypeConversion for BlockNumber {
     type Raw = i64;
-    type Error = DbReprConvError;
+    type Error = DatabaseTypeConversionError;
     fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
         #[allow(clippy::cast_sign_loss)]
         if raw <= u32::MAX as i64 {
             Ok(BlockNumber::from(raw as u32))
         } else {
-            Err(DbReprConvError(type_name::<BlockNumber>()))
+            Err(DatabaseTypeConversionError(type_name::<BlockNumber>()))
         }
     }
     fn to_raw_sql(self) -> Self::Raw {
@@ -62,21 +62,21 @@ impl DbReprConv for BlockNumber {
     }
 }
 
-impl DbReprConv for NetworkAccountPrefix {
+impl DatabaseTypeConversion for NetworkAccountPrefix {
     type Raw = i64;
-    type Error = DbReprConvError;
+    type Error = DatabaseTypeConversionError;
     fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
         NetworkAccountPrefix::try_from(raw as u32)
-            .map_err(|_e| DbReprConvError(type_name::<NetworkAccountError>()))
+            .map_err(|_e| DatabaseTypeConversionError(type_name::<NetworkAccountError>()))
     }
     fn to_raw_sql(self) -> Self::Raw {
         self.inner() as i64
     }
 }
 
-impl DbReprConv for NoteTag {
+impl DatabaseTypeConversion for NoteTag {
     type Raw = i32;
-    type Error = DbReprConvError;
+    type Error = DatabaseTypeConversionError;
 
     #[inline(always)]
     fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {

--- a/crates/store/src/db/models/conv.rs
+++ b/crates/store/src/db/models/conv.rs
@@ -50,12 +50,9 @@ impl SqlTypeConvert for BlockNumber {
     type Raw = i64;
     type Error = DatabaseTypeConversionError;
     fn from_raw_sql(raw: Self::Raw) -> Result<Self, Self::Error> {
-        #[allow(clippy::cast_sign_loss)]
-        if raw <= u32::MAX as i64 {
-            Ok(BlockNumber::from(raw as u32))
-        } else {
-            Err(DatabaseTypeConversionError(type_name::<BlockNumber>()))
-        }
+        u32::try_from(raw)
+            .map(BlockNumber::from)
+            .map_err(|_| DatabaseTypeConversionError(type_name::<BlockNumber>()))
     }
     fn to_raw_sql(self) -> Self::Raw {
         self.as_u32() as i64

--- a/crates/store/src/db/models/conv.rs
+++ b/crates/store/src/db/models/conv.rs
@@ -27,8 +27,71 @@
     reason = "This is the one file where we map the signed database types to the working types"
 )]
 
-use miden_node_proto::domain::account::NetworkAccountPrefix;
-use miden_objects::{Felt, note::NoteTag};
+use std::any::type_name;
+
+use miden_node_proto::domain::account::{NetworkAccountError, NetworkAccountPrefix};
+use miden_objects::{Felt, block::BlockNumber, note::NoteTag};
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed to convert a database value to it's in memory type {0}")]
+pub struct DbReprConvError(&'static str);
+
+/// Convert from and to it's database representation and back
+///
+/// We do not assume sanity of DB types.
+pub(crate) trait DbReprConv: Sized {
+    type Raw: Sized;
+    type Error: std::error::Error + Send + Sync + 'static;
+    fn to_raw_sql(self) -> Self::Raw;
+    fn from_raw_sql(_raw: Self::Raw) -> ::std::result::Result<Self, Self::Error>;
+}
+
+impl DbReprConv for BlockNumber {
+    type Raw = i64;
+    type Error = DbReprConvError;
+    fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
+        #[allow(clippy::cast_sign_loss)]
+        if raw <= u32::MAX as i64 {
+            Ok(BlockNumber::from(raw as u32))
+        } else {
+            Err(DbReprConvError(type_name::<BlockNumber>()))
+        }
+    }
+    fn to_raw_sql(self) -> Self::Raw {
+        self.as_u32() as i64
+    }
+}
+
+impl DbReprConv for NetworkAccountPrefix {
+    type Raw = i64;
+    type Error = DbReprConvError;
+    fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
+        NetworkAccountPrefix::try_from(raw as u32)
+            .map_err(|_e| DbReprConvError(type_name::<NetworkAccountError>()))
+    }
+    fn to_raw_sql(self) -> Self::Raw {
+        self.inner() as i64
+    }
+}
+
+impl DbReprConv for NoteTag {
+    type Raw = i32;
+    type Error = DbReprConvError;
+
+    #[inline(always)]
+    fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
+        #[allow(clippy::cast_sign_loss)]
+        Ok(NoteTag::from(raw as u32))
+    }
+
+    #[inline(always)]
+    fn to_raw_sql(self) -> Self::Raw {
+        u32::from(self) as i32
+    }
+}
+
+// Raw type conversions - eventually introduce wrapper types
+// ===========================================================
 
 #[inline(always)]
 pub(crate) fn raw_sql_to_consumed(raw: i32) -> bool {
@@ -49,15 +112,6 @@ pub(crate) fn raw_sql_to_nullifier_prefix(raw: i32) -> u16 {
 #[inline(always)]
 pub(crate) fn nullifier_prefix_to_raw_sql(prefix: u16) -> i32 {
     prefix as i32
-}
-
-#[inline(always)]
-pub(crate) fn network_account_prefix_to_raw_sql(prefix: NetworkAccountPrefix) -> i64 {
-    prefix.inner() as i64
-}
-#[inline(always)]
-pub(crate) fn raw_sql_to_network_account_prefix(raw: i64) -> NetworkAccountPrefix {
-    NetworkAccountPrefix::try_from(raw as u32).unwrap()
 }
 
 #[inline(always)]
@@ -97,16 +151,6 @@ pub(crate) fn raw_sql_to_note_type(raw: i32) -> u8 {
 #[inline(always)]
 pub(crate) fn note_type_to_raw_sql(note_type_: u8) -> i32 {
     note_type_ as i32
-}
-
-#[inline(always)]
-#[allow(clippy::cast_sign_loss)]
-pub(crate) fn raw_sql_to_tag(raw: i32) -> NoteTag {
-    NoteTag::from(raw as u32)
-}
-#[inline(always)]
-pub(crate) fn tag_to_raw_sql(tag: NoteTag) -> i32 {
-    u32::from(tag) as i32
 }
 
 #[inline(always)]

--- a/crates/store/src/db/models/conv.rs
+++ b/crates/store/src/db/models/conv.rs
@@ -39,17 +39,17 @@ pub struct DatabaseTypeConversionError(&'static str);
 /// Convert from and to it's database representation and back
 ///
 /// We do not assume sanity of DB types.
-pub(crate) trait DatabaseTypeConversion: Sized {
+pub(crate) trait SqlTypeConvert: Sized {
     type Raw: Sized;
     type Error: std::error::Error + Send + Sync + 'static;
     fn to_raw_sql(self) -> Self::Raw;
-    fn from_raw_sql(_raw: Self::Raw) -> ::std::result::Result<Self, Self::Error>;
+    fn from_raw_sql(_raw: Self::Raw) -> Result<Self, Self::Error>;
 }
 
-impl DatabaseTypeConversion for BlockNumber {
+impl SqlTypeConvert for BlockNumber {
     type Raw = i64;
     type Error = DatabaseTypeConversionError;
-    fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
+    fn from_raw_sql(raw: Self::Raw) -> Result<Self, Self::Error> {
         #[allow(clippy::cast_sign_loss)]
         if raw <= u32::MAX as i64 {
             Ok(BlockNumber::from(raw as u32))
@@ -62,10 +62,10 @@ impl DatabaseTypeConversion for BlockNumber {
     }
 }
 
-impl DatabaseTypeConversion for NetworkAccountPrefix {
+impl SqlTypeConvert for NetworkAccountPrefix {
     type Raw = i64;
     type Error = DatabaseTypeConversionError;
-    fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
+    fn from_raw_sql(raw: Self::Raw) -> Result<Self, Self::Error> {
         NetworkAccountPrefix::try_from(raw as u32)
             .map_err(|_e| DatabaseTypeConversionError(type_name::<NetworkAccountError>()))
     }
@@ -74,12 +74,12 @@ impl DatabaseTypeConversion for NetworkAccountPrefix {
     }
 }
 
-impl DatabaseTypeConversion for NoteTag {
+impl SqlTypeConvert for NoteTag {
     type Raw = i32;
     type Error = DatabaseTypeConversionError;
 
     #[inline(always)]
-    fn from_raw_sql(raw: Self::Raw) -> ::std::result::Result<Self, Self::Error> {
+    fn from_raw_sql(raw: Self::Raw) -> Result<Self, Self::Error> {
         #[allow(clippy::cast_sign_loss)]
         Ok(NoteTag::from(raw as u32))
     }

--- a/crates/store/src/db/models/mod.rs
+++ b/crates/store/src/db/models/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     errors::DatabaseError,
 };
 
-mod conv;
+pub(crate) mod conv;
 
 pub mod queries;
 mod types;

--- a/crates/store/src/db/models/queries.rs
+++ b/crates/store/src/db/models/queries.rs
@@ -41,17 +41,15 @@ use crate::{
         NoteRecord, NoteSyncRecord, NoteSyncUpdate, NullifierInfo, Page, StateSyncUpdate,
         TransactionSummary,
         models::{
-            AccountRaw, AccountSummaryRaw, BigIntSum, ExpressionMethods, NoteRecordRaw,
-            TransactionSummaryRaw, block_number_to_raw_sql,
+            AccountRaw, AccountSummaryRaw, BigIntSum, ExpressionMethods, NoteInsertRowRaw,
+            NoteRecordRaw, NoteRecordWithScriptRaw, TransactionSummaryRaw,
             conv::{
-                aux_to_raw_sql, consumed_to_raw_sql, execution_hint_to_raw_sql,
-                execution_mode_to_raw_sql, fungible_delta_to_raw_sql, idx_to_raw_sql,
-                network_account_prefix_to_raw_sql, nonce_to_raw_sql, note_type_to_raw_sql,
+                DbReprConv, consumed_to_raw_sql, fungible_delta_to_raw_sql, nonce_to_raw_sql,
                 nullifier_prefix_to_raw_sql, raw_sql_to_idx, raw_sql_to_nonce, raw_sql_to_slot,
-                slot_to_raw_sql, tag_to_raw_sql,
+                slot_to_raw_sql,
             },
-            deserialize_raw_vec, get_nullifier_prefix, raw_sql_to_block_number, serialize_vec,
-            sql_sum_into, vec_raw_try_into,
+            deserialize_raw_vec, get_nullifier_prefix, serialize_vec, sql_sum_into,
+            vec_raw_try_into,
         },
         schema,
     },
@@ -110,7 +108,7 @@ pub(crate) fn select_notes_since_block_by_tag_and_sender(
     let desired_note_tags = Vec::from_iter(note_tags.iter().map(|tag| *tag as i32));
     let desired_senders = serialize_vec(account_ids.iter());
 
-    let start_block_num = block_number_to_raw_sql(start_block_number);
+    let start_block_num = start_block_number.to_raw_sql();
 
     // find block_num: select notes since block by tag and sender
     let Some(desired_block_num): Option<i64> =
@@ -162,7 +160,7 @@ pub(crate) fn select_block_header_by_block_num(
     let sel = SelectDsl::select(schema::block_headers::table, models::BlockHeaderRaw::as_select());
     let row = if let Some(block_number) = maybe_block_number {
         // SELECT block_header FROM block_headers WHERE block_num = ?1
-        sel.filter(schema::block_headers::block_num.eq(block_number_to_raw_sql(block_number)))
+        sel.filter(schema::block_headers::block_num.eq(block_number.to_raw_sql()))
             .get_result::<models::BlockHeaderRaw>(conn)
             .optional()?
         // invariant: only one block exists with the given block header, so the length is
@@ -220,7 +218,7 @@ pub(crate) fn select_note_inclusion_proofs(
     Result::<BTreeMap<_, _>, _>::from_iter(raw_notes.iter().map(
         |(block_num, note_id, batch_index, note_index, merkle_path)| {
             let note_id = NoteId::read_from_bytes(&note_id[..])?;
-            let block_num = raw_sql_to_block_number(*block_num);
+            let block_num = BlockNumber::from_raw_sql(*block_num)?;
             let node_index_in_block =
                 BlockNoteIndex::new(raw_sql_to_idx(*batch_index), raw_sql_to_idx(*note_index))
                     .expect("batch and note index from DB should be valid")
@@ -248,7 +246,7 @@ pub(crate) fn insert_block_header(
 ) -> Result<usize, DatabaseError> {
     let count = diesel::insert_into(schema::block_headers::table)
         .values(&[(
-            schema::block_headers::block_num.eq(block_number_to_raw_sql(block_header.block_num())),
+            schema::block_headers::block_num.eq(block_header.block_num().to_raw_sql()),
             schema::block_headers::block_header.eq(block_header.to_bytes()),
         )])
         .execute(conn)?;
@@ -290,7 +288,7 @@ pub(crate) fn insert_account_delta(
         let count = diesel::insert_into(schema::account_deltas::table)
             .values(&[(
                 schema::account_deltas::account_id.eq(account_id.to_bytes()),
-                schema::account_deltas::block_num.eq(block_number_to_raw_sql(block_num)),
+                schema::account_deltas::block_num.eq(block_num.to_raw_sql()),
                 schema::account_deltas::nonce.eq(nonce_to_raw_sql(nonce)),
             )])
             .execute(conn)?;
@@ -307,8 +305,7 @@ pub(crate) fn insert_account_delta(
         let count = diesel::insert_into(schema::account_storage_slot_updates::table)
             .values(&[(
                 schema::account_storage_slot_updates::account_id.eq(account_id.to_bytes()),
-                schema::account_storage_slot_updates::block_num
-                    .eq(block_number_to_raw_sql(block_num)),
+                schema::account_storage_slot_updates::block_num.eq(block_num.to_raw_sql()),
                 schema::account_storage_slot_updates::slot.eq(slot_to_raw_sql(slot)),
                 schema::account_storage_slot_updates::value.eq(value),
             )])
@@ -327,8 +324,7 @@ pub(crate) fn insert_account_delta(
         let count = diesel::insert_into(schema::account_storage_map_updates::table)
             .values(&[(
                 schema::account_storage_map_updates::account_id.eq(account_id.to_bytes()),
-                schema::account_storage_map_updates::block_num
-                    .eq(block_number_to_raw_sql(block_num)),
+                schema::account_storage_map_updates::block_num.eq(block_num.to_raw_sql()),
                 schema::account_storage_map_updates::slot.eq(slot_to_raw_sql(slot)),
                 schema::account_storage_map_updates::key.eq(key),
                 schema::account_storage_map_updates::value.eq(value),
@@ -347,8 +343,7 @@ pub(crate) fn insert_account_delta(
         let count = diesel::insert_into(schema::account_fungible_asset_deltas::table)
             .values(&[(
                 schema::account_fungible_asset_deltas::account_id.eq(account_id.to_bytes()),
-                schema::account_fungible_asset_deltas::block_num
-                    .eq(block_number_to_raw_sql(block_num)),
+                schema::account_fungible_asset_deltas::block_num.eq(block_num.to_raw_sql()),
                 schema::account_fungible_asset_deltas::faucet_id.eq(faucet_id),
                 schema::account_fungible_asset_deltas::delta.eq(fungible_delta_to_raw_sql(delta)),
             )])
@@ -366,8 +361,7 @@ pub(crate) fn insert_account_delta(
         let count = diesel::insert_into(schema::account_non_fungible_asset_updates::table)
             .values(&[(
                 schema::account_non_fungible_asset_updates::account_id.eq(account_id.to_bytes()),
-                schema::account_non_fungible_asset_updates::block_num
-                    .eq(block_number_to_raw_sql(block_num)),
+                schema::account_non_fungible_asset_updates::block_num.eq(block_num.to_raw_sql()),
                 schema::account_non_fungible_asset_updates::vault_key.eq(vault_key),
                 schema::account_non_fungible_asset_updates::is_remove.eq(is_remove),
             )])
@@ -537,9 +531,9 @@ pub(crate) fn upsert_accounts(
         let val = (
             schema::accounts::account_id.eq(account_id.to_bytes()),
             schema::accounts::network_account_id_prefix
-                .eq(network_account_id_prefix.map(network_account_prefix_to_raw_sql)),
+                .eq(network_account_id_prefix.map(DbReprConv::to_raw_sql)),
             schema::accounts::account_commitment.eq(update.final_state_commitment().to_bytes()),
-            schema::accounts::block_num.eq(block_number_to_raw_sql(block_num)),
+            schema::accounts::block_num.eq(block_num.to_raw_sql()),
             schema::accounts::details.eq(full_account.as_ref().map(|account| account.to_bytes())),
         );
         let v = val.clone();
@@ -578,31 +572,11 @@ pub(crate) fn insert_notes(
     notes: &[(NoteRecord, Option<Nullifier>)],
 ) -> Result<usize, DatabaseError> {
     let count = diesel::insert_into(schema::notes::table)
-        .values(Vec::from_iter(notes.iter().map(|(note, nullifier)| {
-            (
-                schema::notes::block_num.eq(block_number_to_raw_sql(note.block_num)),
-                schema::notes::batch_index.eq(idx_to_raw_sql(note.note_index.batch_idx())),
-                schema::notes::note_index.eq(idx_to_raw_sql(note.note_index.note_idx_in_batch())),
-                schema::notes::note_id.eq(note.note_id.to_bytes()),
-                schema::notes::note_type.eq(note_type_to_raw_sql(note.metadata.note_type() as u8)),
-                schema::notes::sender.eq(note.metadata.sender().to_bytes()),
-                schema::notes::tag.eq(tag_to_raw_sql(note.metadata.tag())),
-                schema::notes::execution_mode
-                    .eq(execution_mode_to_raw_sql(note.metadata.tag().execution_mode() as i32)),
-                schema::notes::aux.eq(aux_to_raw_sql(note.metadata.aux())),
-                schema::notes::execution_hint
-                    .eq(execution_hint_to_raw_sql(note.metadata.execution_hint().into())),
-                schema::notes::inclusion_path.eq(note.inclusion_path.to_bytes()),
-                schema::notes::consumed.eq(consumed_to_raw_sql(false)), // New notes are always unconsumed.
-                schema::notes::nullifier.eq(nullifier.as_ref().map(Nullifier::to_bytes)), // Beware: `Option<T>` also implements `to_bytes`, but this is not what you want.
-                schema::notes::assets.eq(note.details.as_ref().map(|d| d.assets().to_bytes())),
-                schema::notes::inputs.eq(note.details.as_ref().map(|d| d.inputs().to_bytes())),
-                schema::notes::script_root
-                    .eq(note.details.as_ref().map(|d| d.script().root().to_bytes())),
-                schema::notes::serial_num
-                    .eq(note.details.as_ref().map(|d| d.serial_num().to_bytes())),
-            )
-        })))
+        .values(Vec::from_iter(
+            notes
+                .iter()
+                .map(|(note, nullifier)| NoteInsertRowRaw::from((note.clone(), *nullifier))),
+        ))
         .execute(conn)?;
     Ok(count)
 }
@@ -657,7 +631,7 @@ pub(crate) fn insert_transactions(
             (
                 schema::transactions::transaction_id.eq(tx.id().to_bytes()),
                 schema::transactions::account_id.eq(tx.account_id().to_bytes()),
-                schema::transactions::block_num.eq(block_number_to_raw_sql(block_num)),
+                schema::transactions::block_num.eq(block_num.to_raw_sql()),
             )
         })))
         .execute(conn)?;
@@ -674,37 +648,18 @@ pub(crate) fn select_notes_by_id(
     // LEFT JOIN note_scripts ON notes.script_root = note_scripts.script_root
     // WHERE note_id IN rarray(?1),
 
-    let cols = (
-        schema::notes::block_num,
-        schema::notes::batch_index,
-        schema::notes::note_index,
-        schema::notes::note_id,
-        // metadata
-        schema::notes::note_type,
-        schema::notes::sender,
-        schema::notes::tag,
-        schema::notes::aux,
-        schema::notes::execution_hint,
-        // details
-        schema::notes::assets,
-        schema::notes::inputs,
-        schema::notes::serial_num,
-        // // merkle
-        schema::notes::inclusion_path,
-        schema::note_scripts::script.nullable(),
-    );
-
     let q = schema::notes::table
         .left_join(
             schema::note_scripts::table
                 .on(schema::notes::script_root.eq(schema::note_scripts::script_root.nullable())),
         )
         .filter(schema::notes::note_id.eq_any(&note_ids));
-    let raw: Vec<_> = SelectDsl::select(
-        q, cols, // NoteRecordRaw::as_select()
-    )
-    .load::<NoteRecordRaw>(conn)?;
-    let records = vec_raw_try_into::<NoteRecord, _>(raw)?;
+    let raw: Vec<_> =
+        SelectDsl::select(q, (NoteRecordRaw::as_select(), schema::note_scripts::script.nullable()))
+            .load::<(NoteRecordRaw, Option<Vec<u8>>)>(conn)?;
+    let records = vec_raw_try_into::<NoteRecord, NoteRecordWithScriptRaw>(
+        raw.into_iter().map(NoteRecordWithScriptRaw::from),
+    )?;
     Ok(records)
 }
 
@@ -722,36 +677,17 @@ pub(crate) fn select_all_notes(
     // FROM notes
     // LEFT JOIN note_scripts ON notes.script_root = note_scripts.script_root
     // ORDER BY block_num ASC
-    let cols = (
-        schema::notes::block_num,
-        schema::notes::batch_index,
-        schema::notes::note_index,
-        schema::notes::note_id,
-        // metadata
-        schema::notes::note_type,
-        schema::notes::sender,
-        schema::notes::tag,
-        schema::notes::aux,
-        schema::notes::execution_hint,
-        // details
-        schema::notes::assets,
-        schema::notes::inputs,
-        schema::notes::serial_num,
-        // merkle
-        schema::notes::inclusion_path,
-        schema::note_scripts::script.nullable(),
-    );
-
     let q = schema::notes::table.left_join(
         schema::note_scripts::table
             .on(schema::notes::script_root.eq(schema::note_scripts::script_root.nullable())),
     );
-    let raw: Vec<_> = SelectDsl::select(
-        q, cols, // does not work: NoteRecordRaw::as_select()
-    )
-    .order(schema::notes::block_num.asc())
-    .load::<NoteRecordRaw>(conn)?;
-    let records = vec_raw_try_into::<NoteRecord, _>(raw)?;
+    let raw: Vec<_> =
+        SelectDsl::select(q, (NoteRecordRaw::as_select(), schema::note_scripts::script.nullable()))
+            .order(schema::notes::block_num.asc())
+            .load::<(NoteRecordRaw, Option<Vec<u8>>)>(conn)?;
+    let records = vec_raw_try_into::<NoteRecord, NoteRecordWithScriptRaw>(
+        raw.into_iter().map(NoteRecordWithScriptRaw::from),
+    )?;
     Ok(records)
 }
 
@@ -806,7 +742,7 @@ pub(crate) fn insert_nullifiers_for_block(
                     schema::nullifiers::nullifier.eq(bytes),
                     schema::nullifiers::nullifier_prefix
                         .eq(nullifier_prefix_to_raw_sql(get_nullifier_prefix(nullifier))),
-                    schema::nullifiers::block_num.eq(block_number_to_raw_sql(block_num)),
+                    schema::nullifiers::block_num.eq(block_num.to_raw_sql()),
                 )
             },
         )))
@@ -870,7 +806,7 @@ pub(crate) fn select_nullifiers_by_prefix(
         models::NullifierWithoutPrefixRawRow::as_select(),
     )
     .filter(schema::nullifiers::nullifier_prefix.eq_any(prefixes))
-    .filter(schema::nullifiers::block_num.ge(block_number_to_raw_sql(block_num)))
+    .filter(schema::nullifiers::block_num.ge(block_num.to_raw_sql()))
     .order(schema::nullifiers::block_num.asc())
     .load::<models::NullifierWithoutPrefixRawRow>(conn)?;
     vec_raw_try_into(nullifiers_raw)
@@ -1001,20 +937,8 @@ pub(crate) fn unconsumed_network_notes(
         reason = "It's only relevant for a single call function"
     )]
     type RawLoadedTuple = (
-        i64,             // block_num
-        i32,             // batch_index
-        i32,             // note_index
-        Vec<u8>,         // note_id
-        i32,             // note_type
-        Vec<u8>,         // sender
-        i32,             // tag
-        i64,             // aux
-        i64,             // execution_hint
-        Vec<u8>,         // merkle_path
-        Option<Vec<u8>>, // assets
-        Option<Vec<u8>>, // inputs
+        NoteRecordRaw,
         Option<Vec<u8>>, // script
-        Option<Vec<u8>>, // serial_num
         i64,             // rowid (from sql::<BigInt>("notes.rowid"))
     );
 
@@ -1024,26 +948,10 @@ pub(crate) fn unconsumed_network_notes(
     )]
     fn split_into_raw_note_record_and_implicit_row_id(
         tuple: RawLoadedTuple,
-    ) -> (NoteRecordRaw, i64) {
-        (
-            NoteRecordRaw {
-                block_num: tuple.0,
-                batch_index: tuple.1,
-                note_index: tuple.2,
-                note_id: tuple.3,
-                note_type: tuple.4,
-                sender: tuple.5,
-                tag: tuple.6,
-                aux: tuple.7,
-                execution_hint: tuple.8,
-                merkle_path: tuple.9,
-                assets: tuple.10,
-                inputs: tuple.11,
-                script: tuple.12,
-                serial_num: tuple.13,
-            },
-            tuple.14,
-        )
+    ) -> (NoteRecordWithScriptRaw, i64) {
+        let (note, script, row) = tuple;
+        let combined = NoteRecordWithScriptRaw::from((note, script));
+        (combined, row)
     }
 
     let raw = SelectDsl::select(
@@ -1052,22 +960,8 @@ pub(crate) fn unconsumed_network_notes(
                 .on(schema::notes::script_root.eq(schema::note_scripts::script_root.nullable())),
         ),
         (
-            schema::notes::block_num,
-            schema::notes::batch_index,
-            schema::notes::note_index,
-            schema::notes::note_id,
-            // metadata
-            schema::notes::note_type,
-            schema::notes::sender,
-            schema::notes::tag,
-            schema::notes::aux,
-            schema::notes::execution_hint,
-            schema::notes::inclusion_path,
-            // details
-            schema::notes::assets,
-            schema::notes::inputs,
+            NoteRecordRaw::as_select(),
             schema::note_scripts::script.nullable(),
-            schema::notes::serial_num,
             rowid_sel.clone(),
         ),
     )
@@ -1223,8 +1117,8 @@ pub(crate) fn select_nonce_stmt(
     // WHERE
     //     account_id = ?1 AND block_num > ?2 AND block_num <= ?3
     let desired_account_id = account_id.to_bytes();
-    let start_block_num = block_number_to_raw_sql(start_block_num);
-    let end_block_num = block_number_to_raw_sql(end_block_num);
+    let start_block_num = start_block_num.to_raw_sql();
+    let end_block_num = end_block_num.to_raw_sql();
 
     // Note: The following does not work as anticipated for `BigInt` columns,
     // since `Foldable` for `BigInt` requires `Numeric`, which is only supported
@@ -1282,8 +1176,8 @@ pub(crate) fn select_slot_updates_stmt(
     //             b.block_num <= ?3
     //     )
     let desired_account_id = account_id_val.to_bytes();
-    let start_block_num = block_number_to_raw_sql(start_block_num);
-    let end_block_num = block_number_to_raw_sql(end_block_num);
+    let start_block_num = start_block_num.to_raw_sql();
+    let end_block_num = end_block_num.to_raw_sql();
 
     // Alias the table for the inner and outer query
     let (a, b) = alias!(
@@ -1343,8 +1237,8 @@ pub(crate) fn select_storage_map_updates_stmt(
     use schema::account_storage_map_updates::dsl::{account_id, block_num, key, slot, value};
 
     let desired_account_id = account_id_val.to_bytes();
-    let start_block_num = block_number_to_raw_sql(start_block_num);
-    let end_block_num = block_number_to_raw_sql(end_block_num);
+    let start_block_num = start_block_num.to_raw_sql();
+    let end_block_num = end_block_num.to_raw_sql();
 
     // Alias the table for the inner and outer query
     let (a, b) = alias!(
@@ -1393,8 +1287,8 @@ pub(crate) fn select_fungible_asset_deltas_stmt(
     // GROUP BY
     //     faucet_id
     let desired_account_id = account_id.to_bytes();
-    let start_block_num = block_number_to_raw_sql(start_block_num);
-    let end_block_num = block_number_to_raw_sql(end_block_num);
+    let start_block_num = start_block_num.to_raw_sql();
+    let end_block_num = end_block_num.to_raw_sql();
 
     let values: Vec<(Vec<u8>, Option<BigIntSum>)> = SelectDsl::select(
         schema::account_fungible_asset_deltas::table
@@ -1447,8 +1341,8 @@ pub(crate) fn select_non_fungible_asset_updates_stmt(
     // ORDER BY
     //     block_num
     let desired_account_id = account_id.to_bytes();
-    let start_block_num = block_number_to_raw_sql(start_block_num);
-    let end_block_num = block_number_to_raw_sql(end_block_num);
+    let start_block_num = start_block_num.to_raw_sql();
+    let end_block_num = end_block_num.to_raw_sql();
 
     let entries = SelectDsl::select(
         schema::account_non_fungible_asset_updates::table,
@@ -1489,7 +1383,7 @@ pub fn select_block_headers(
     QueryParamBlockLimit::check(blocks.size_hint().0)?;
 
     // SELECT block_header FROM block_headers WHERE block_num IN rarray(?1)
-    let blocks = Vec::from_iter(blocks.map(block_number_to_raw_sql));
+    let blocks = Vec::from_iter(blocks.map(DbReprConv::to_raw_sql));
     let raw_block_headers =
         QueryDsl::select(schema::block_headers::table, models::BlockHeaderRaw::as_select())
             .filter(schema::block_headers::block_num.eq_any(blocks))
@@ -1534,8 +1428,8 @@ pub(crate) fn get_state_sync(
         .ok_or_else(|| StateSyncError::EmptyBlockHeadersTable)?;
 
     // select accounts by block range
-    let block_start = block_number_to_raw_sql(since_block_number);
-    let block_end = block_number_to_raw_sql(block_header.block_num());
+    let block_start = since_block_number.to_raw_sql();
+    let block_end = block_header.block_num().to_raw_sql();
     let account_updates =
         select_accounts_by_block_range(conn, &account_ids, block_start, block_end)?;
 

--- a/crates/store/src/db/models/queries.rs
+++ b/crates/store/src/db/models/queries.rs
@@ -44,9 +44,9 @@ use crate::{
             AccountRaw, AccountSummaryRaw, BigIntSum, ExpressionMethods, NoteInsertRowRaw,
             NoteRecordRaw, NoteRecordWithScriptRaw, TransactionSummaryRaw,
             conv::{
-                DatabaseTypeConversion, consumed_to_raw_sql, fungible_delta_to_raw_sql,
-                nonce_to_raw_sql, nullifier_prefix_to_raw_sql, raw_sql_to_idx, raw_sql_to_nonce,
-                raw_sql_to_slot, slot_to_raw_sql,
+                SqlTypeConvert, consumed_to_raw_sql, fungible_delta_to_raw_sql, nonce_to_raw_sql,
+                nullifier_prefix_to_raw_sql, raw_sql_to_idx, raw_sql_to_nonce, raw_sql_to_slot,
+                slot_to_raw_sql,
             },
             deserialize_raw_vec, get_nullifier_prefix, serialize_vec, sql_sum_into,
             vec_raw_try_into,
@@ -531,7 +531,7 @@ pub(crate) fn upsert_accounts(
         let val = (
             schema::accounts::account_id.eq(account_id.to_bytes()),
             schema::accounts::network_account_id_prefix
-                .eq(network_account_id_prefix.map(DatabaseTypeConversion::to_raw_sql)),
+                .eq(network_account_id_prefix.map(SqlTypeConvert::to_raw_sql)),
             schema::accounts::account_commitment.eq(update.final_state_commitment().to_bytes()),
             schema::accounts::block_num.eq(block_num.to_raw_sql()),
             schema::accounts::details.eq(full_account.as_ref().map(|account| account.to_bytes())),
@@ -1383,7 +1383,7 @@ pub fn select_block_headers(
     QueryParamBlockLimit::check(blocks.size_hint().0)?;
 
     // SELECT block_header FROM block_headers WHERE block_num IN rarray(?1)
-    let blocks = Vec::from_iter(blocks.map(DatabaseTypeConversion::to_raw_sql));
+    let blocks = Vec::from_iter(blocks.map(SqlTypeConvert::to_raw_sql));
     let raw_block_headers =
         QueryDsl::select(schema::block_headers::table, models::BlockHeaderRaw::as_select())
             .filter(schema::block_headers::block_num.eq_any(blocks))

--- a/crates/store/src/db/models/queries.rs
+++ b/crates/store/src/db/models/queries.rs
@@ -44,9 +44,9 @@ use crate::{
             AccountRaw, AccountSummaryRaw, BigIntSum, ExpressionMethods, NoteInsertRowRaw,
             NoteRecordRaw, NoteRecordWithScriptRaw, TransactionSummaryRaw,
             conv::{
-                DbReprConv, consumed_to_raw_sql, fungible_delta_to_raw_sql, nonce_to_raw_sql,
-                nullifier_prefix_to_raw_sql, raw_sql_to_idx, raw_sql_to_nonce, raw_sql_to_slot,
-                slot_to_raw_sql,
+                DatabaseTypeConversion, consumed_to_raw_sql, fungible_delta_to_raw_sql,
+                nonce_to_raw_sql, nullifier_prefix_to_raw_sql, raw_sql_to_idx, raw_sql_to_nonce,
+                raw_sql_to_slot, slot_to_raw_sql,
             },
             deserialize_raw_vec, get_nullifier_prefix, serialize_vec, sql_sum_into,
             vec_raw_try_into,
@@ -531,7 +531,7 @@ pub(crate) fn upsert_accounts(
         let val = (
             schema::accounts::account_id.eq(account_id.to_bytes()),
             schema::accounts::network_account_id_prefix
-                .eq(network_account_id_prefix.map(DbReprConv::to_raw_sql)),
+                .eq(network_account_id_prefix.map(DatabaseTypeConversion::to_raw_sql)),
             schema::accounts::account_commitment.eq(update.final_state_commitment().to_bytes()),
             schema::accounts::block_num.eq(block_num.to_raw_sql()),
             schema::accounts::details.eq(full_account.as_ref().map(|account| account.to_bytes())),
@@ -1383,7 +1383,7 @@ pub fn select_block_headers(
     QueryParamBlockLimit::check(blocks.size_hint().0)?;
 
     // SELECT block_header FROM block_headers WHERE block_num IN rarray(?1)
-    let blocks = Vec::from_iter(blocks.map(DbReprConv::to_raw_sql));
+    let blocks = Vec::from_iter(blocks.map(DatabaseTypeConversion::to_raw_sql));
     let raw_block_headers =
         QueryDsl::select(schema::block_headers::table, models::BlockHeaderRaw::as_select())
             .filter(schema::block_headers::block_num.eq_any(blocks))

--- a/crates/store/src/db/models/types.rs
+++ b/crates/store/src/db/models/types.rs
@@ -19,7 +19,7 @@ use super::{
     Selectable, Sqlite, accounts, block_headers, notes, nullifiers, transactions,
 };
 use crate::db::models::conv::{
-    DbReprConv, aux_to_raw_sql, consumed_to_raw_sql, execution_hint_to_raw_sql,
+    DatabaseTypeConversion, aux_to_raw_sql, consumed_to_raw_sql, execution_hint_to_raw_sql,
     execution_mode_to_raw_sql, idx_to_raw_sql, note_type_to_raw_sql,
 };
 

--- a/crates/store/src/db/models/types.rs
+++ b/crates/store/src/db/models/types.rs
@@ -1,10 +1,11 @@
 use bigdecimal::BigDecimal;
-use miden_lib::utils::Deserializable;
+use diesel::prelude::Insertable;
+use miden_lib::utils::{Deserializable, Serializable};
 use miden_node_proto::{self as proto, domain::account::AccountSummary};
 use miden_objects::{
     Felt, Word,
     account::{Account, AccountId},
-    block::{BlockHeader, BlockNoteIndex},
+    block::{BlockHeader, BlockNoteIndex, BlockNumber},
     crypto::merkle::SparseMerklePath,
     note::{
         NoteAssets, NoteDetails, NoteExecutionHint, NoteInputs, NoteMetadata, NoteRecipient,
@@ -15,8 +16,11 @@ use miden_objects::{
 
 use super::{
     DatabaseError, NoteRecord, NoteSyncRecord, NullifierInfo, Queryable, QueryableByName,
-    Selectable, Sqlite, accounts, block_headers, notes, nullifiers, raw_sql_to_block_number,
-    transactions,
+    Selectable, Sqlite, accounts, block_headers, notes, nullifiers, transactions,
+};
+use crate::db::models::conv::{
+    DbReprConv, aux_to_raw_sql, consumed_to_raw_sql, execution_hint_to_raw_sql,
+    execution_mode_to_raw_sql, idx_to_raw_sql, note_type_to_raw_sql,
 };
 
 #[derive(Debug, Clone, Queryable, QueryableByName, Selectable)]
@@ -35,7 +39,7 @@ impl TryInto<proto::domain::account::AccountInfo> for AccountRaw {
         use proto::domain::account::{AccountInfo, AccountSummary};
         let account_id = AccountId::read_from_bytes(&self.account_id[..])?;
         let account_commitment = Word::read_from_bytes(&self.account_commitment[..])?;
-        let block_num = raw_sql_to_block_number(self.block_num);
+        let block_num = BlockNumber::from_raw_sql(self.block_num)?;
         let summary = AccountSummary {
             account_id,
             account_commitment,
@@ -58,7 +62,7 @@ impl TryInto<NullifierInfo> for NullifierWithoutPrefixRawRow {
     type Error = DatabaseError;
     fn try_into(self) -> Result<NullifierInfo, Self::Error> {
         let nullifier = Nullifier::read_from_bytes(&self.nullifier)?;
-        let block_num = raw_sql_to_block_number(self.block_num);
+        let block_num = BlockNumber::from_raw_sql(self.block_num)?;
         Ok(NullifierInfo { nullifier, block_num })
     }
 }
@@ -93,7 +97,7 @@ impl TryInto<crate::db::TransactionSummary> for TransactionSummaryRaw {
     fn try_into(self) -> Result<crate::db::TransactionSummary, Self::Error> {
         Ok(crate::db::TransactionSummary {
             account_id: AccountId::read_from_bytes(&self.account_id[..])?,
-            block_num: raw_sql_to_block_number(self.block_num),
+            block_num: BlockNumber::from_raw_sql(self.block_num)?,
             transaction_id: TransactionId::read_from_bytes(&self.transaction_id[..])?,
         })
     }
@@ -163,7 +167,7 @@ pub struct NoteSyncRecordRawRow {
 impl TryInto<NoteSyncRecord> for NoteSyncRecordRawRow {
     type Error = DatabaseError;
     fn try_into(self) -> Result<NoteSyncRecord, Self::Error> {
-        let block_num = raw_sql_to_block_number(self.block_num);
+        let block_num = BlockNumber::from_raw_sql(self.block_num)?;
         let note_index = self.block_note_index.try_into()?;
 
         let note_id = Word::read_from_bytes(&self.note_id[..])?;
@@ -193,7 +197,7 @@ impl TryInto<AccountSummary> for AccountSummaryRaw {
     fn try_into(self) -> Result<AccountSummary, Self::Error> {
         let account_id = AccountId::read_from_bytes(&self.account_id[..])?;
         let account_commitment = Word::read_from_bytes(&self.account_commitment[..])?;
-        let block_num = raw_sql_to_block_number(self.block_num);
+        let block_num = BlockNumber::from_raw_sql(self.block_num)?;
 
         Ok(AccountSummary {
             account_id,
@@ -217,7 +221,7 @@ pub struct NoteDetailsRaw {
 // when used with join and debugging is painful to put it
 // mildly.
 #[derive(Debug, Clone, PartialEq, Queryable)]
-pub struct NoteRecordRaw {
+pub struct NoteRecordWithScriptRaw {
     pub block_num: i64,
 
     pub batch_index: i32,
@@ -239,16 +243,52 @@ pub struct NoteRecordRaw {
 
     // #[diesel(embed)]
     // pub details: NoteDetailsRaw,
-    pub merkle_path: Vec<u8>,
+    pub inclusion_path: Vec<u8>,
     pub script: Option<Vec<u8>>, // not part of notes::table!
 }
 
-impl TryInto<NoteRecord> for NoteRecordRaw {
+impl From<(NoteRecordRaw, Option<Vec<u8>>)> for NoteRecordWithScriptRaw {
+    fn from((note, script): (NoteRecordRaw, Option<Vec<u8>>)) -> Self {
+        let NoteRecordRaw {
+            block_num,
+            batch_index,
+            note_index,
+            note_id,
+            note_type,
+            sender,
+            tag,
+            aux,
+            execution_hint,
+            assets,
+            inputs,
+            serial_num,
+            inclusion_path,
+        } = note;
+        Self {
+            block_num,
+            batch_index,
+            note_index,
+            note_id,
+            note_type,
+            sender,
+            tag,
+            aux,
+            execution_hint,
+            assets,
+            inputs,
+            serial_num,
+            inclusion_path,
+            script,
+        }
+    }
+}
+
+impl TryInto<NoteRecord> for NoteRecordWithScriptRaw {
     type Error = DatabaseError;
     fn try_into(self) -> Result<NoteRecord, Self::Error> {
         // let (raw, script) = self;
         let raw = self;
-        let NoteRecordRaw {
+        let NoteRecordWithScriptRaw {
             block_num,
 
             batch_index,
@@ -266,7 +306,7 @@ impl TryInto<NoteRecord> for NoteRecordRaw {
             inputs,
             serial_num,
             //details ^^^,
-            merkle_path,
+            inclusion_path,
             script,
             ..
         } = raw;
@@ -281,7 +321,7 @@ impl TryInto<NoteRecord> for NoteRecordRaw {
         let details = NoteDetailsRaw { assets, inputs, serial_num };
 
         let metadata = metadata.try_into()?;
-        let block_num = raw_sql_to_block_number(block_num);
+        let block_num = BlockNumber::from_raw_sql(block_num)?;
         let note_id = Word::read_from_bytes(&note_id[..])?;
         let script = script.map(|script| NoteScript::read_from_bytes(&script[..])).transpose()?;
         let details = if let NoteDetailsRaw {
@@ -301,7 +341,7 @@ impl TryInto<NoteRecord> for NoteRecordRaw {
         } else {
             None
         };
-        let inclusion_path = SparseMerklePath::read_from_bytes(&merkle_path[..])?;
+        let inclusion_path = SparseMerklePath::read_from_bytes(&inclusion_path[..])?;
         let note_index = index.try_into()?;
         Ok(NoteRecord {
             block_num,
@@ -312,6 +352,29 @@ impl TryInto<NoteRecord> for NoteRecordRaw {
             inclusion_path,
         })
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Selectable, Queryable, QueryableByName)]
+#[diesel(table_name = notes)]
+#[diesel(check_for_backend(Sqlite))]
+pub struct NoteRecordRaw {
+    pub block_num: i64,
+
+    pub batch_index: i32,
+    pub note_index: i32, // index within batch
+    pub note_id: Vec<u8>,
+
+    pub note_type: i32,
+    pub sender: Vec<u8>, // AccountId
+    pub tag: i32,
+    pub aux: i64,
+    pub execution_hint: i64,
+
+    pub assets: Option<Vec<u8>>,
+    pub inputs: Option<Vec<u8>>,
+    pub serial_num: Option<Vec<u8>>,
+
+    pub inclusion_path: Vec<u8>,
 }
 
 /// A type to represent a `sum(BigInt)`
@@ -341,4 +404,54 @@ where
         source: Box::new(e),
     })?;
     Ok::<_, DatabaseError>(val)
+}
+
+#[derive(Debug, Clone, PartialEq, Insertable)]
+#[diesel(table_name = notes)]
+pub struct NoteInsertRowRaw {
+    pub block_num: i64,
+
+    pub batch_index: i32,
+    pub note_index: i32, // index within batch
+
+    pub note_id: Vec<u8>,
+
+    pub note_type: i32,
+    pub sender: Vec<u8>, // AccountId
+    pub tag: i32,
+    pub aux: i64,
+    pub execution_hint: i64,
+
+    pub consumed: i32,
+    pub assets: Option<Vec<u8>>,
+    pub inputs: Option<Vec<u8>>,
+    pub serial_num: Option<Vec<u8>>,
+    pub nullifier: Option<Vec<u8>>,
+    pub script_root: Option<Vec<u8>>,
+    pub execution_mode: i32,
+    pub inclusion_path: Vec<u8>,
+}
+
+impl From<(NoteRecord, Option<Nullifier>)> for NoteInsertRowRaw {
+    fn from((note, nullifier): (NoteRecord, Option<Nullifier>)) -> Self {
+        Self {
+            block_num: note.block_num.to_raw_sql(),
+            batch_index: idx_to_raw_sql(note.note_index.batch_idx()),
+            note_index: idx_to_raw_sql(note.note_index.note_idx_in_batch()),
+            note_id: note.note_id.to_bytes(),
+            note_type: note_type_to_raw_sql(note.metadata.note_type() as u8),
+            sender: note.metadata.sender().to_bytes(),
+            tag: note.metadata.tag().to_raw_sql(),
+            execution_mode: execution_mode_to_raw_sql(note.metadata.tag().execution_mode() as i32),
+            aux: aux_to_raw_sql(note.metadata.aux()),
+            execution_hint: execution_hint_to_raw_sql(note.metadata.execution_hint().into()),
+            inclusion_path: note.inclusion_path.to_bytes(),
+            consumed: consumed_to_raw_sql(false), // New notes are always unconsumed.
+            nullifier: nullifier.as_ref().map(Nullifier::to_bytes), /* Beware: `Option<T>` also implements `to_bytes`, but this is not what you want. */
+            assets: note.details.as_ref().map(|d| d.assets().to_bytes()),
+            inputs: note.details.as_ref().map(|d| d.inputs().to_bytes()),
+            script_root: note.details.as_ref().map(|d| d.script().root().to_bytes()),
+            serial_num: note.details.as_ref().map(|d| d.serial_num().to_bytes()),
+        }
+    }
 }

--- a/crates/store/src/db/models/types.rs
+++ b/crates/store/src/db/models/types.rs
@@ -19,7 +19,7 @@ use super::{
     Selectable, Sqlite, accounts, block_headers, notes, nullifiers, transactions,
 };
 use crate::db::models::conv::{
-    DatabaseTypeConversion, aux_to_raw_sql, consumed_to_raw_sql, execution_hint_to_raw_sql,
+    SqlTypeConvert, aux_to_raw_sql, consumed_to_raw_sql, execution_hint_to_raw_sql,
     execution_mode_to_raw_sql, idx_to_raw_sql, note_type_to_raw_sql,
 };
 

--- a/crates/store/src/db/models/utils.rs
+++ b/crates/store/src/db/models/utils.rs
@@ -1,7 +1,6 @@
 use diesel::{Connection, RunQueryDsl, SqliteConnection};
 use miden_lib::utils::{Deserializable, DeserializationError, Serializable};
-use miden_node_proto::generated::blockchain::Block;
-use miden_objects::{block::BlockNumber, note::Nullifier};
+use miden_objects::note::Nullifier;
 
 use crate::errors::DatabaseError;
 
@@ -30,25 +29,6 @@ pub(crate) fn serialize_vec<'a, D: Serializable + 'a>(
     raw: impl IntoIterator<Item = &'a D>,
 ) -> Vec<Vec<u8>> {
     Vec::<_>::from_iter(raw.into_iter().map(<D as Serializable>::to_bytes))
-}
-
-// TODO once all integers are wrapper types, use something like
-trait FlatAndBloat {
-    type Raw: Sized;
-    fn to_raw_sql(self) -> Self::Raw;
-    fn from_raw_sql(_raw: Self::Raw) -> Self;
-}
-
-impl FlatAndBloat for BlockNumber {
-    type Raw = i64;
-    fn from_raw_sql(raw: Self::Raw) -> Self {
-        debug_assert!(raw <= u32::MAX as i64);
-        #[allow(clippy::cast_sign_loss)]
-        BlockNumber::from(raw as u32)
-    }
-    fn to_raw_sql(self) -> Self::Raw {
-        self.as_u32() as i64
-    }
 }
 
 /// Returns the high 16 bits of the provided nullifier.

--- a/crates/store/src/db/models/utils.rs
+++ b/crates/store/src/db/models/utils.rs
@@ -1,5 +1,6 @@
 use diesel::{Connection, RunQueryDsl, SqliteConnection};
 use miden_lib::utils::{Deserializable, DeserializationError, Serializable};
+use miden_node_proto::generated::blockchain::Block;
 use miden_objects::{block::BlockNumber, note::Nullifier};
 
 use crate::errors::DatabaseError;
@@ -32,46 +33,27 @@ pub(crate) fn serialize_vec<'a, D: Serializable + 'a>(
 }
 
 // TODO once all integers are wrapper types, use something like
-// trait FlatAndBloat {
-//     type Raw = i64;
-//     fn to_raw_sql(self) -> Self::Raw;
-//     fn from_raw_sql(Self::Raw) -> Self;
-// }
-
-/// Convert the database type `BigInt` into a blocknumber
-///
-/// Attention: We use `u32` as actual in-memory representation, since this will
-/// suffice well beyond all our lifetimes.
-pub(crate) fn raw_sql_to_block_number(raw: impl Into<i64>) -> BlockNumber {
-    let raw = raw.into();
-    debug_assert!(raw <= u32::MAX as i64);
-    #[allow(clippy::cast_sign_loss)]
-    BlockNumber::from(raw as u32)
+trait FlatAndBloat {
+    type Raw: Sized;
+    fn to_raw_sql(self) -> Self::Raw;
+    fn from_raw_sql(_raw: Self::Raw) -> Self;
 }
 
-/// Convert the in-memory type `BlockNumber` into the database type `BigInt`
-///
-/// Attention: We use `u32` as actual in-memory representation, since this will
-/// suffice well beyond all our lifetimes.
-pub(crate) fn block_number_to_raw_sql(block_num: BlockNumber) -> i64 {
-    block_num.as_u32() as i64
+impl FlatAndBloat for BlockNumber {
+    type Raw = i64;
+    fn from_raw_sql(raw: Self::Raw) -> Self {
+        debug_assert!(raw <= u32::MAX as i64);
+        #[allow(clippy::cast_sign_loss)]
+        BlockNumber::from(raw as u32)
+    }
+    fn to_raw_sql(self) -> Self::Raw {
+        self.as_u32() as i64
+    }
 }
 
 /// Returns the high 16 bits of the provided nullifier.
 pub fn get_nullifier_prefix(nullifier: &Nullifier) -> u16 {
     (nullifier.most_significant_felt().as_int() >> 48) as u16
-}
-
-/// Checks if a table exists in the database.
-#[allow(dead_code)]
-pub fn table_exists(conn: &mut SqliteConnection, table_name: &str) -> Result<bool, DatabaseError> {
-    conn.transaction(|conn| {
-        let count =
-            diesel::sql_query("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = $1")
-                .bind::<diesel::sql_types::Text, &str>(table_name)
-                .execute(conn)?;
-        Ok::<bool, DatabaseError>(count > 0)
-    })
 }
 
 /// Converts a slice of length `N` to an array, returns `None` if invariant

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
 use tonic::Status;
 
-use crate::db::{manager::ConnectionManagerError, models::conv::DbReprConvError};
+use crate::db::{manager::ConnectionManagerError, models::conv::DatabaseTypeConversionError};
 
 // DATABASE ERRORS
 // =================================================================================================
@@ -95,7 +95,7 @@ pub enum DatabaseError {
     #[error(transparent)]
     ConnectionManager(#[from] ConnectionManagerError),
     #[error(transparent)]
-    SqlValueConversion(#[from] DbReprConvError),
+    SqlValueConversion(#[from] DatabaseTypeConversionError),
 }
 
 impl DatabaseError {

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
 use tonic::Status;
 
-use crate::db::manager::ConnectionManagerError;
+use crate::db::{manager::ConnectionManagerError, models::conv::DbReprConvError};
 
 // DATABASE ERRORS
 // =================================================================================================
@@ -94,6 +94,8 @@ pub enum DatabaseError {
     UnsupportedDatabaseVersion,
     #[error(transparent)]
     ConnectionManager(#[from] ConnectionManagerError),
+    #[error(transparent)]
+    SqlValueConversion(#[from] DbReprConvError),
 }
 
 impl DatabaseError {


### PR DESCRIPTION
* Avoids excessive usage of tuple and indexing into them, but prefers types and named fields
* first step to wrapper types for all DB stored and retrieved values