### PR TITLE
fix: Flaky test_prove_transaction

### DIFF
--- a/bin/remote-prover/src/api/prover.rs
+++ b/bin/remote-prover/src/api/prover.rs
@@ -279,14 +279,13 @@ mod test {
         // Create a mock transaction to send to the server
         let mut mock_chain_builder = MockChainBuilder::new();
         let account = mock_chain_builder.add_existing_wallet(Auth::BasicAuth).unwrap();
-        let mut mock_chain = mock_chain_builder.build().unwrap();
 
         let fungible_asset_1: Asset =
             FungibleAsset::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into().unwrap(), 100)
                 .unwrap()
                 .into();
-        let note_1 = mock_chain
-            .add_pending_p2id_note(
+        let note_1 = mock_chain_builder
+            .add_p2id_note(
                 ACCOUNT_ID_SENDER.try_into().unwrap(),
                 account.id(),
                 &[fungible_asset_1],
@@ -294,10 +293,11 @@ mod test {
             )
             .unwrap();
 
+        let mock_chain = mock_chain_builder.build().unwrap();
+
         let tx_context = mock_chain
-            .build_tx_context(account.id(), &[], &[])
+            .build_tx_context(account.id(), &[note_1.id()], &[])
             .unwrap()
-            .extend_input_notes(vec![note_1])
             .build()
             .unwrap();
 

--- a/bin/remote-prover/src/api/prover.rs
+++ b/bin/remote-prover/src/api/prover.rs
@@ -316,12 +316,8 @@ mod test {
         });
 
         // Send both requests concurrently
-        let (t1, t2) = (
-            tokio::spawn(async move { client.prove(request_1).await }),
-            tokio::spawn(async move { client_2.prove(request_2).await }),
-        );
-
-        let (response_1, response_2) = (t1.await.unwrap(), t2.await.unwrap());
+        let (response_1, response_2) =
+            tokio::join!(client.prove(request_1), client_2.prove(request_2));
 
         // Check the success response
         assert!(response_1.is_ok() || response_2.is_ok());


### PR DESCRIPTION
## Context

Closes #1102.

Sometimes the `test_prove_transaction` fixture will fail locally on line `330`:
```rust
        // Check the failure response
        assert!(response_1.is_err() || response_2.is_err());
```

## Changes
- Fix failing test by adding tokio join of relevant tasks.
- Use `MockBuilder` to add note for execution.