### PR TITLE
fix: Fix underflow

### DIFF
--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -204,7 +204,7 @@ impl State {
 
         // Keep MMR pruned.
         let pruned_block_height =
-            (self.chain_mmr.chain_length().as_usize() - MAX_BLOCK_COUNT) as u32;
+            (self.chain_mmr.chain_length().as_usize().saturating_sub(MAX_BLOCK_COUNT)) as u32;
         self.chain_mmr.prune_to(..pruned_block_height.into());
     }
 


### PR DESCRIPTION
Bootstrapping a new node leads to error caused by panic due to arithmetic underflow:

```
   ./target/debug/miden-node bundled bootstrap --data-directory /tmp/1 --accounts-directory /tmp/1
   ./target/debug/miden-node bundled start --rpc.url http://0.0.0.0:57291 --data-directory /tmp/1
```

will cause
```
Error: Component ntx-builder failed

Caused by:
    0: Joining component task
    1: task 20 panicked with message "attempt to subtract with overflow"
```

This fixes the underflow.