### PR TITLE
test: fix `GenesisConfig` test

### DIFF
--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -44,7 +44,7 @@ tracing                = { workspace = true }
 assert_matches        = { workspace = true }
 miden-lib             = { features = ["testing"], workspace = true }
 miden-node-test-macro = { workspace = true }
-miden-node-utils      = { features = ["tracing-forest"], workspace = true }
+miden-node-utils      = { features = ["tracing-forest", "testing"], workspace = true }
 miden-objects         = { default-features = true, features = ["testing"], workspace = true }
 pretty_assertions     = { workspace = true }
 rand                  = { workspace = true }


### PR DESCRIPTION
This test was failing since the [last PR merge](https://github.com/0xMiden/miden-node/actions/runs/17043558181/job/48313283604).
It didn't come up while the [PR was on review](https://github.com/0xMiden/miden-node/actions/runs/17046924559/job/48325685660?pr=1132) apparently though.

The main problem seemed to be that the test is based on account ordering as defined in the TOML, but this order is not guaranteed due to the accounts passing through a `HashMap` first. For this I switched to a `BTreeMap`, but there might be some other way to do this. For example, I'm not sure but it seems like `TokenSymbolStr` could have been introduced for `Hash`. Or maybe the test should not be based on the ordering itself and this behavior could be documented. 
