### PR TITLE
fix: Enforce single target network notes in NTB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - RPC requests with wildcard (`*/*`) media-type are not longer rejected ([#1084](https://github.com/0xMiden/miden-node/pull/1084)).
 - Stress-test CLI account now properly sets the storage mode and increment nonce in transactions ([#1113](https://github.com/0xMiden/miden-node/pull/1113)).
 - [BREAKING] Update `notes` table schema to have a nullable `consumed_block_num` ([#1100](https://github.com/0xMiden/miden-node/pull/1100)).
+- Network Transaction Builder checks that a `Note` is single target when validating conversion to `NetworkNote` ([#1166](https://github.com/0xMiden/miden-node/pull/1166)).
 
 ## v0.10.1 (2025-07-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - RPC requests with wildcard (`*/*`) media-type are not longer rejected ([#1084](https://github.com/0xMiden/miden-node/pull/1084)).
 - Stress-test CLI account now properly sets the storage mode and increment nonce in transactions ([#1113](https://github.com/0xMiden/miden-node/pull/1113)).
 - [BREAKING] Update `notes` table schema to have a nullable `consumed_block_num` ([#1100](https://github.com/0xMiden/miden-node/pull/1100)).
-- Network Transaction Builder checks that a `Note` is single target when validating conversion to `NetworkNote` ([#1166](https://github.com/0xMiden/miden-node/pull/1166)).
+- Network Transaction Builder now correctly discards non-single-target network notes instead of panicking ([#1166](https://github.com/0xMiden/miden-node/pull/1166)).
 
 ## v0.10.1 (2025-07-14)
 

--- a/crates/ntx-builder/src/state/account.rs
+++ b/crates/ntx-builder/src/state/account.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 
 use miden_node_proto::domain::account::NetworkAccountPrefix;
-use miden_node_proto::domain::note::NetworkNote;
+use miden_node_proto::domain::note::SingleTargetNetworkNote;
 use miden_objects::account::delta::AccountUpdateDetails;
 use miden_objects::account::{Account, AccountDelta, AccountId};
 use miden_objects::block::BlockNumber;
@@ -17,14 +17,14 @@ use miden_objects::note::{Note, Nullifier};
 /// will likely be soon after the number that is recorded here.
 #[derive(Debug, Clone)]
 pub struct InflightNetworkNote {
-    note: NetworkNote,
+    note: SingleTargetNetworkNote,
     attempt_count: usize,
     last_attempt: Option<BlockNumber>,
 }
 
 impl InflightNetworkNote {
     /// Creates a new inflight network note.
-    pub fn new(note: NetworkNote) -> Self {
+    pub fn new(note: SingleTargetNetworkNote) -> Self {
         Self {
             note,
             attempt_count: 0,
@@ -33,12 +33,12 @@ impl InflightNetworkNote {
     }
 
     /// Consumes the inflight network note and returns the inner network note.
-    pub fn into_inner(self) -> NetworkNote {
+    pub fn into_inner(self) -> SingleTargetNetworkNote {
         self.note
     }
 
     /// Returns a reference to the inner network note.
-    pub fn to_inner(&self) -> &NetworkNote {
+    pub fn to_inner(&self) -> &SingleTargetNetworkNote {
         &self.note
     }
 
@@ -159,7 +159,7 @@ impl AccountState {
     }
 
     /// Adds a new network note making it available for consumption.
-    pub fn add_note(&mut self, note: NetworkNote) {
+    pub fn add_note(&mut self, note: SingleTargetNetworkNote) {
         self.available_notes.insert(note.nullifier(), InflightNetworkNote::new(note));
     }
 

--- a/crates/ntx-builder/src/state/account.rs
+++ b/crates/ntx-builder/src/state/account.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 
 use miden_node_proto::domain::account::NetworkAccountPrefix;
-use miden_node_proto::domain::note::SingleTargetNetworkNote;
+use miden_node_proto::domain::note::NetworkNote;
 use miden_objects::account::delta::AccountUpdateDetails;
 use miden_objects::account::{Account, AccountDelta, AccountId};
 use miden_objects::block::BlockNumber;
@@ -17,14 +17,14 @@ use miden_objects::note::{Note, Nullifier};
 /// will likely be soon after the number that is recorded here.
 #[derive(Debug, Clone)]
 pub struct InflightNetworkNote {
-    note: SingleTargetNetworkNote,
+    note: NetworkNote,
     attempt_count: usize,
     last_attempt: Option<BlockNumber>,
 }
 
 impl InflightNetworkNote {
     /// Creates a new inflight network note.
-    pub fn new(note: SingleTargetNetworkNote) -> Self {
+    pub fn new(note: NetworkNote) -> Self {
         Self {
             note,
             attempt_count: 0,
@@ -33,12 +33,12 @@ impl InflightNetworkNote {
     }
 
     /// Consumes the inflight network note and returns the inner network note.
-    pub fn into_inner(self) -> SingleTargetNetworkNote {
+    pub fn into_inner(self) -> NetworkNote {
         self.note
     }
 
     /// Returns a reference to the inner network note.
-    pub fn to_inner(&self) -> &SingleTargetNetworkNote {
+    pub fn to_inner(&self) -> &NetworkNote {
         &self.note
     }
 
@@ -159,7 +159,7 @@ impl AccountState {
     }
 
     /// Adds a new network note making it available for consumption.
-    pub fn add_note(&mut self, note: SingleTargetNetworkNote) {
+    pub fn add_note(&mut self, note: NetworkNote) {
         self.available_notes.insert(note.nullifier(), InflightNetworkNote::new(note));
     }
 

--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -6,7 +6,7 @@ use account::{AccountState, InflightNetworkNote, NetworkAccountUpdate};
 use anyhow::Context;
 use miden_node_proto::domain::account::NetworkAccountPrefix;
 use miden_node_proto::domain::mempool::MempoolEvent;
-use miden_node_proto::domain::note::NetworkNote;
+use miden_node_proto::domain::note::SingleTargetNetworkNote;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_objects::account::Account;
 use miden_objects::account::delta::AccountUpdateDetails;
@@ -265,7 +265,7 @@ impl State {
             } => {
                 let network_notes = network_notes
                     .into_iter()
-                    .filter(|note| note.metadata().tag().is_single_target())
+                    .filter_map(|note| SingleTargetNetworkNote::try_from(note).ok())
                     .collect::<Vec<_>>();
                 self.add_transaction(id, nullifiers, network_notes, account_delta).await?;
             },
@@ -304,7 +304,7 @@ impl State {
         &mut self,
         id: TransactionId,
         nullifiers: Vec<Nullifier>,
-        network_notes: Vec<NetworkNote>,
+        network_notes: Vec<SingleTargetNetworkNote>,
         account_delta: Option<AccountUpdateDetails>,
     ) -> anyhow::Result<()> {
         // Skip transactions we already know about.

--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -116,7 +116,7 @@ impl State {
 
         let notes = state.store.get_unconsumed_network_notes().await?;
         for note in notes {
-            // Single target network notes only.
+            // TODO: support multi target network notes.
             if let Some(prefix) = note.account_prefix() {
                 // Ignore notes which don't target an existing account.
                 let Some(account) = state.fetch_account(prefix).await? else {

--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -263,6 +263,10 @@ impl State {
                 network_notes,
                 account_delta,
             } => {
+                let network_notes = network_notes
+                    .into_iter()
+                    .filter(|note| note.metadata().tag().is_single_target())
+                    .collect::<Vec<_>>();
                 self.add_transaction(id, nullifiers, network_notes, account_delta).await?;
             },
             MempoolEvent::BlockCommitted { header, txs } => {

--- a/crates/ntx-builder/src/state/mod.rs
+++ b/crates/ntx-builder/src/state/mod.rs
@@ -266,12 +266,9 @@ impl State {
             } => {
                 let network_notes = network_notes
                     .into_iter()
-                    .filter_map(|note| {
-                        if let NetworkNote::SingleTarget(note) = note {
-                            Some(note)
-                        } else {
-                            None
-                        }
+                    .filter_map(|note| match note {
+                        NetworkNote::SingleTarget(note) => Some(note),
+                        NetworkNote::MultiTarget(_) => None,
                     })
                     .collect::<Vec<_>>();
                 self.add_transaction(id, nullifiers, network_notes, account_delta).await?;

--- a/crates/ntx-builder/src/store.rs
+++ b/crates/ntx-builder/src/store.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use miden_node_proto::clients::{Builder, StoreNtxBuilder, StoreNtxBuilderClient};
 use miden_node_proto::domain::account::NetworkAccountPrefix;
-use miden_node_proto::domain::note::NetworkNote;
+use miden_node_proto::domain::note::SingleTargetNetworkNote;
 use miden_node_proto::errors::ConversionError;
 use miden_node_proto::generated::{self as proto};
 use miden_node_proto::try_convert;
@@ -104,7 +104,9 @@ impl StoreClient {
 
     /// Returns the list of unconsumed network notes.
     #[instrument(target = COMPONENT, name = "store.client.get_unconsumed_network_notes", skip_all, err)]
-    pub async fn get_unconsumed_network_notes(&self) -> Result<Vec<NetworkNote>, StoreError> {
+    pub async fn get_unconsumed_network_notes(
+        &self,
+    ) -> Result<Vec<SingleTargetNetworkNote>, StoreError> {
         let mut all_notes = Vec::new();
         let mut page_token: Option<u64> = None;
 
@@ -115,10 +117,10 @@ impl StoreClient {
             };
             let resp = self.inner.clone().get_unconsumed_network_notes(req).await?.into_inner();
 
-            let page: Vec<NetworkNote> = resp
+            let page: Vec<SingleTargetNetworkNote> = resp
                 .notes
                 .into_iter()
-                .map(NetworkNote::try_from)
+                .map(SingleTargetNetworkNote::try_from)
                 .collect::<Result<Vec<_>, _>>()?;
 
             all_notes.extend(page);

--- a/crates/ntx-builder/src/store.rs
+++ b/crates/ntx-builder/src/store.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use miden_node_proto::clients::{Builder, StoreNtxBuilder, StoreNtxBuilderClient};
 use miden_node_proto::domain::account::NetworkAccountPrefix;
-use miden_node_proto::domain::note::SingleTargetNetworkNote;
+use miden_node_proto::domain::note::NetworkNote;
 use miden_node_proto::errors::ConversionError;
 use miden_node_proto::generated::{self as proto};
 use miden_node_proto::try_convert;
@@ -104,9 +104,7 @@ impl StoreClient {
 
     /// Returns the list of unconsumed network notes.
     #[instrument(target = COMPONENT, name = "store.client.get_unconsumed_network_notes", skip_all, err)]
-    pub async fn get_unconsumed_network_notes(
-        &self,
-    ) -> Result<Vec<SingleTargetNetworkNote>, StoreError> {
+    pub async fn get_unconsumed_network_notes(&self) -> Result<Vec<NetworkNote>, StoreError> {
         let mut all_notes = Vec::new();
         let mut page_token: Option<u64> = None;
 
@@ -117,10 +115,10 @@ impl StoreClient {
             };
             let resp = self.inner.clone().get_unconsumed_network_notes(req).await?.into_inner();
 
-            let page: Vec<SingleTargetNetworkNote> = resp
+            let page: Vec<NetworkNote> = resp
                 .notes
                 .into_iter()
-                .map(SingleTargetNetworkNote::try_from)
+                .map(NetworkNote::try_from)
                 .collect::<Result<Vec<_>, _>>()?;
 
             all_notes.extend(page);

--- a/crates/proto/src/domain/note.rs
+++ b/crates/proto/src/domain/note.rs
@@ -297,7 +297,7 @@ impl SingleTargetNetworkNote {
         self.metadata()
             .tag()
             .try_into()
-            .expect("SingleTargetNetworkNotes have network account prefix")
+            .expect("Single target network note's tag should contain an account prefix")
     }
 }
 

--- a/crates/proto/src/domain/note.rs
+++ b/crates/proto/src/domain/note.rs
@@ -217,10 +217,12 @@ impl TryFrom<Note> for NetworkNote {
     type Error = NetworkNoteError;
 
     fn try_from(note: Note) -> Result<Self, Self::Error> {
-        if !note.is_network_note() {
-            return Err(NetworkNoteError::InvalidExecutionMode(note.metadata().tag()));
+        // Only support network notes targeted at a single network account.
+        if note.is_network_note() && note.metadata().tag().is_single_target() {
+            Ok(NetworkNote(note))
+        } else {
+            Err(NetworkNoteError::InvalidExecutionMode(note.metadata().tag()))
         }
-        Ok(NetworkNote(note))
     }
 }
 

--- a/crates/proto/src/domain/note.rs
+++ b/crates/proto/src/domain/note.rs
@@ -217,8 +217,7 @@ impl TryFrom<Note> for NetworkNote {
     type Error = NetworkNoteError;
 
     fn try_from(note: Note) -> Result<Self, Self::Error> {
-        // Only support network notes targeted at a single network account.
-        if note.is_network_note() && note.metadata().tag().is_single_target() {
+        if note.is_network_note() {
             Ok(NetworkNote(note))
         } else {
             Err(NetworkNoteError::InvalidExecutionMode(note.metadata().tag()))


### PR DESCRIPTION
## Context

Closes #1115.

The NTB only supports single target network notes and does not currently check for this when constructing `NetworkNote` from `Note`.

## Changes
- Update `NetworkNote` to be an enum with single and multi target variants.
- Add `SingleTargetNetworkNote` and `MultiTargetNetworkNote` types.
- Use `SingleTargetNetworkNote` in NTB.