### PR TITLE
chore: add --locked to remote prover install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ install-faucet: ## Installs faucet
 
 .PHONY: install-remote-prover
 install-remote-prover: ## Install remote prover's CLI
-	$(BUILD_PROTO) cargo install --path bin/remote-prover --bin miden-remote-prover --features concurrent
+	$(BUILD_PROTO) cargo install --path bin/remote-prover --bin miden-remote-prover --features concurrent --locked
 
 .PHONY: install-stress-test
 install-stress-test: ## Installs stress-test binary


### PR DESCRIPTION
closes #433 