### PR TITLE
chore: update Rust version in Dockerfile and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-node/blob/main/LICENSE)
 [![test](https://github.com/0xMiden/miden-node/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/miden-node/actions/workflows/test.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.88+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.89+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-node)](https://crates.io/crates/miden-node)
 
 Welcome to the Miden node implementation :) This software is used to operate a Miden ZK-rollup network by

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88-slim-bullseye AS builder
+FROM rust:1.89-slim-bullseye AS builder
 
 RUN apt-get update && \
     apt-get -y upgrade && \

--- a/docs/src/operator/installation.md
+++ b/docs/src/operator/installation.md
@@ -25,7 +25,7 @@ can be used so long as the checksum file and the package file are in the same fo
 
 ## Install using `cargo`
 
-Install Rust version **1.88** or greater using the official Rust installation
+Install Rust version **1.89** or greater using the official Rust installation
 [instructions](https://www.rust-lang.org/tools/install).
 
 Depending on the platform, you may need to install additional libraries. For example, on Ubuntu 22.04 the following


### PR DESCRIPTION
CI is currently failing in next because the MSRV of the repo is 1.89 but it wasn't updated in the Dockerfile (and used 1.88). Also updated README and installation docs.