### PR TITLE
`node-proto-build` - better protox errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,8 @@ dependencies = [
 name = "miden-node-proto-build"
 version = "0.12.0"
 dependencies = [
- "anyhow",
+ "fs-err",
+ "miette",
  "prost",
  "protox",
  "tonic-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,11 +2263,13 @@ name = "miden-node-proto"
 version = "0.12.0"
 dependencies = [
  "anyhow",
+ "fs-err",
  "hex",
  "http",
  "miden-node-proto-build",
  "miden-node-utils",
  "miden-objects",
+ "miette",
  "proptest",
  "prost",
  "prost-build",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -29,7 +29,8 @@ url              = { workspace = true }
 proptest = { version = "1.7" }
 
 [build-dependencies]
-anyhow                 = { workspace = true }
+miette                 = { version = "7.6" }
+fs-err                 = { workspace = true}
 miden-node-proto-build = { features = ["internal"], workspace = true }
 prost                  = { workspace = true }
 prost-build            = { version = "0.13" }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -29,9 +29,9 @@ url              = { workspace = true }
 proptest = { version = "1.7" }
 
 [build-dependencies]
-miette                 = { version = "7.6" }
-fs-err                 = { workspace = true}
+fs-err                 = { workspace = true }
 miden-node-proto-build = { features = ["internal"], workspace = true }
+miette                 = { version = "7.6" }
 prost                  = { workspace = true }
 prost-build            = { version = "0.13" }
 protox                 = { version = "0.8" }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -1,7 +1,7 @@
+use std::env;
 use std::path::{Path, PathBuf};
-use std::{env, fs};
 
-use anyhow::Context;
+use fs_err as fs;
 use miden_node_proto_build::{
     block_producer_api_descriptor,
     rpc_api_descriptor,
@@ -10,13 +10,14 @@ use miden_node_proto_build::{
     store_rpc_api_descriptor,
     store_shared_api_descriptor,
 };
+use miette::{Context, IntoDiagnostic};
 use tonic_build::FileDescriptorSet;
 
 /// Generates Rust protobuf bindings using miden-node-proto-build.
 ///
 /// This is done only if `BUILD_PROTO` environment variable is set to `1` to avoid running the
 /// script on crates.io where repo-level .proto files are not available.
-fn main() -> anyhow::Result<()> {
+fn main() -> miette::Result<()> {
     println!("cargo::rerun-if-changed=../../proto/proto");
     println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 
@@ -30,8 +31,12 @@ fn main() -> anyhow::Result<()> {
     let dst_dir = crate_root.join("src").join("generated");
 
     // Remove all existing files.
-    fs::remove_dir_all(&dst_dir).context("removing existing files")?;
-    fs::create_dir(&dst_dir).context("creating destination folder")?;
+    fs::remove_dir_all(&dst_dir)
+        .into_diagnostic()
+        .wrap_err("removing existing files")?;
+    fs::create_dir(&dst_dir)
+        .into_diagnostic()
+        .wrap_err("creating destination folder")?;
 
     generate_bindings(rpc_api_descriptor(), &dst_dir)?;
     generate_bindings(store_rpc_api_descriptor(), &dst_dir)?;
@@ -40,14 +45,14 @@ fn main() -> anyhow::Result<()> {
     generate_bindings(store_shared_api_descriptor(), &dst_dir)?;
     generate_bindings(block_producer_api_descriptor(), &dst_dir)?;
 
-    generate_mod_rs(&dst_dir).context("generating mod.rs")?;
+    generate_mod_rs(&dst_dir).into_diagnostic().wrap_err("generating mod.rs")?;
 
     Ok(())
 }
 
 /// Generates protobuf bindings from the given file descriptor set and stores them in the
 /// given destination directory.
-fn generate_bindings(file_descriptors: FileDescriptorSet, dst_dir: &Path) -> anyhow::Result<()> {
+fn generate_bindings(file_descriptors: FileDescriptorSet, dst_dir: &Path) -> miette::Result<()> {
     let mut prost_config = prost_build::Config::new();
     prost_config.skip_debug(["AccountId", "Digest"]);
 
@@ -55,7 +60,8 @@ fn generate_bindings(file_descriptors: FileDescriptorSet, dst_dir: &Path) -> any
     tonic_build::configure()
         .out_dir(dst_dir)
         .compile_fds_with_config(prost_config, file_descriptors)
-        .context("compiling protobufs")?;
+        .into_diagnostic()
+        .wrap_err("compiling protobufs")?;
 
     Ok(())
 }
@@ -66,7 +72,7 @@ fn generate_mod_rs(directory: impl AsRef<Path>) -> std::io::Result<()> {
 
     // Discover all submodules by iterating over the folder contents.
     let mut submodules = Vec::new();
-    for entry in fs::read_dir(directory)? {
+    for entry in fs::read_dir(directory.as_ref())? {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() {

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -24,7 +24,7 @@ protox      = { version = "0.8" }
 tonic-build = { version = "0.13" }
 
 [build-dependencies]
+fs-err = { workspace = true }
 miette = { version = "7.6" }
 prost  = { workspace = true }
 protox = { version = "0.8" }
-fs-err = { workspace = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -24,6 +24,7 @@ protox      = { version = "0.8" }
 tonic-build = { version = "0.13" }
 
 [build-dependencies]
-anyhow = { workspace = true }
+miette = { version = "7.6" }
 prost  = { workspace = true }
 protox = { version = "0.8" }
+fs-err = { workspace = true }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,7 +1,8 @@
+use fs_err as fs;
+use miette::{Context, IntoDiagnostic};
+use std::env;
 use std::path::PathBuf;
-use std::{env, fs};
 
-use anyhow::Context;
 use prost::Message;
 
 const RPC_PROTO: &str = "rpc.proto";
@@ -20,19 +21,20 @@ const STORE_SHARED_DESCRIPTOR: &str = "store_shared_file_descriptor.bin";
 const BLOCK_PRODUCER_DESCRIPTOR: &str = "block_producer_file_descriptor.bin";
 const REMOTE_PROVER_DESCRIPTOR: &str = "remote_prover_file_descriptor.bin";
 
-fn main() -> anyhow::Result<()> {
-    run()
+fn main() -> miette::Result<()> {
+    dbg!(run())
 }
 
 /// Generates Rust protobuf bindings from .proto files.
 ///
 /// This is done only if `BUILD_PROTO` environment variable is set to `1` to avoid running the
 /// script on crates.io where repo-level .proto files are not available.
-fn run() -> anyhow::Result<()> {
+fn run() -> miette::Result<()> {
     println!("cargo::rerun-if-changed=./proto");
     println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 
-    let out = env::var("OUT_DIR").context("env::OUT_DIR not set")?;
+    let out =
+        env::var("OUT_DIR").expect("env::OUT_DIR is always set in build.rs when used with cargo");
 
     let crate_root: PathBuf = env!("CARGO_MANIFEST_DIR").into();
     let proto_dir = crate_root.join("proto");
@@ -41,38 +43,45 @@ fn run() -> anyhow::Result<()> {
     let rpc_file_descriptor = protox::compile([RPC_PROTO], includes)?;
     let rpc_path = PathBuf::from(&out).join(RPC_DESCRIPTOR);
     fs::write(&rpc_path, rpc_file_descriptor.encode_to_vec())
-        .context("writing rpc file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing rpc file descriptor")?;
 
     let remote_prover_file_descriptor = protox::compile([REMOTE_PROVER_PROTO], includes)?;
     let remote_prover_path = PathBuf::from(&out).join(REMOTE_PROVER_DESCRIPTOR);
     fs::write(&remote_prover_path, remote_prover_file_descriptor.encode_to_vec())
-        .context("writing remote prover file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing remote prover file descriptor")?;
 
     let store_rpc_file_descriptor = protox::compile([STORE_RPC_PROTO], includes)?;
     let store_rpc_path = PathBuf::from(&out).join(STORE_RPC_DESCRIPTOR);
     fs::write(&store_rpc_path, store_rpc_file_descriptor.encode_to_vec())
-        .context("writing store rpc file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing store rpc file descriptor")?;
 
     let store_ntx_builder_file_descriptor = protox::compile([STORE_NTX_BUILDER_PROTO], includes)?;
     let store_ntx_builder_path = PathBuf::from(&out).join(STORE_NTX_BUILDER_DESCRIPTOR);
     fs::write(&store_ntx_builder_path, store_ntx_builder_file_descriptor.encode_to_vec())
-        .context("writing store ntx builder file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing store ntx builder file descriptor")?;
 
     let store_block_producer_file_descriptor =
         protox::compile([STORE_BLOCK_PRODUCER_PROTO], includes)?;
     let store_block_producer_path = PathBuf::from(&out).join(STORE_BLOCK_PRODUCER_DESCRIPTOR);
     fs::write(&store_block_producer_path, store_block_producer_file_descriptor.encode_to_vec())
-        .context("writing store block producer file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing store block producer file descriptor")?;
 
     let store_shared_file_descriptor = protox::compile([STORE_SHARED_PROTO], includes)?;
     let store_shared_path = PathBuf::from(&out).join(STORE_SHARED_DESCRIPTOR);
     fs::write(&store_shared_path, store_shared_file_descriptor.encode_to_vec())
-        .context("writing store shared file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing store shared file descriptor")?;
 
     let block_producer_file_descriptor = protox::compile([BLOCK_PRODUCER_PROTO], includes)?;
     let block_producer_path = PathBuf::from(&out).join(BLOCK_PRODUCER_DESCRIPTOR);
     fs::write(&block_producer_path, block_producer_file_descriptor.encode_to_vec())
-        .context("writing block producer file descriptor")?;
+        .into_diagnostic()
+        .wrap_err("writing block producer file descriptor")?;
 
     Ok(())
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -20,11 +20,15 @@ const STORE_SHARED_DESCRIPTOR: &str = "store_shared_file_descriptor.bin";
 const BLOCK_PRODUCER_DESCRIPTOR: &str = "block_producer_file_descriptor.bin";
 const REMOTE_PROVER_DESCRIPTOR: &str = "remote_prover_file_descriptor.bin";
 
+fn main() -> anyhow::Result<()> {
+    run()
+}
+
 /// Generates Rust protobuf bindings from .proto files.
 ///
 /// This is done only if `BUILD_PROTO` environment variable is set to `1` to avoid running the
 /// script on crates.io where repo-level .proto files are not available.
-fn main() -> anyhow::Result<()> {
+fn run() -> anyhow::Result<()> {
     println!("cargo::rerun-if-changed=./proto");
     println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,8 +1,8 @@
-use fs_err as fs;
-use miette::{Context, IntoDiagnostic};
 use std::env;
 use std::path::PathBuf;
 
+use fs_err as fs;
+use miette::{Context, IntoDiagnostic};
 use prost::Message;
 
 const RPC_PROTO: &str = "rpc.proto";
@@ -22,7 +22,7 @@ const BLOCK_PRODUCER_DESCRIPTOR: &str = "block_producer_file_descriptor.bin";
 const REMOTE_PROVER_DESCRIPTOR: &str = "remote_prover_file_descriptor.bin";
 
 fn main() -> miette::Result<()> {
-    dbg!(run())
+    run()
 }
 
 /// Generates Rust protobuf bindings from .proto files.

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -21,15 +21,11 @@ const STORE_SHARED_DESCRIPTOR: &str = "store_shared_file_descriptor.bin";
 const BLOCK_PRODUCER_DESCRIPTOR: &str = "block_producer_file_descriptor.bin";
 const REMOTE_PROVER_DESCRIPTOR: &str = "remote_prover_file_descriptor.bin";
 
-fn main() -> miette::Result<()> {
-    run()
-}
-
 /// Generates Rust protobuf bindings from .proto files.
 ///
 /// This is done only if `BUILD_PROTO` environment variable is set to `1` to avoid running the
 /// script on crates.io where repo-level .proto files are not available.
-fn run() -> miette::Result<()> {
+fn main() -> miette::Result<()> {
     println!("cargo::rerun-if-changed=./proto");
     println!("cargo::rerun-if-env-changed=BUILD_PROTO");
 


### PR DESCRIPTION
Currently we reduce `miette::Error` to `anyhow::Error`. This retains the `miette` context, upgrading output from:

```

Caused by:
  process didn't exit successfully: `/media/humpback/projects/miden/miden-node-bernhard-1185-acounts/target/debug/build/miden-node-proto-build-c8b64ef83bec5c7c/build-script-build` (exit status: 1)
  --- stdout
  cargo::rerun-if-changed=./proto
  cargo::rerun-if-env-changed=BUILD_PROTO

  --- stderr
  [proto/build.rs:25:5] color_eyre::install() = Ok(
      (),
  )
  [proto/build.rs:26:5] run() = Err(
      store/rpc.proto:110:19: expected an identifier, but found '{',
  )
  Error: 
     0: expected an identifier, but found '{'

  Location:
     proto/build.rs:43

```

to:

```
  process didn't exit successfully: `/media/humpback/projects/miden/miden-node-bernhard-1185-acounts/target/debug/build/miden-node-proto-build-45f1c9d2f9c973e5/build-script-build` (exit status: 1)
  --- stdout
  cargo::rerun-if-changed=./proto
  cargo::rerun-if-env-changed=BUILD_PROTO

  --- stderr
  [proto/build.rs:25:5] run() = Err(
      store/rpc.proto:119:39: field number '2' is already used,
  )
  Error:   × field number '2' is already used
       ╭─[store/rpc.proto:117:36]
   116 │                 // (e.g., with fewer than 1000 entries).
   117 │                 bool all_entries = 2;
       ·                                    ┬
       ·                                    ╰── first defined here
   118 │ 
   119 │                 AllMapKeys map_keys = 2;
       ·                                       ┬
       ·                                       ╰── defined again here
   120 │             }
       ╰────

  Error: 
    × name 'Digest' is not defined
       ╭─[store/rpc.proto:109:26]
   108 │                 // A list of map keys (Digests) associated with this storage slot.
   109 │                 repeated Digest map_keys = 1;
       ·                          ───┬──
       ·                             ╰── found here
   110 │             }
       ╰────

  Error: 
    × name 'AccountWitness' is not defined
       ╭─[store/rpc.proto:168:5]
   167 │     // Account ID, current state commitment, and SMT path
   168 │     AccountWitness witness = 1;
       ·     ───────┬──────
       ·            ╰── found here
   169 │ 
       ╰────

  Error: 
    × name 'AccountHeader' is not defined
       ╭─[store/rpc.proto:155:9]
   154 │         // Account header.
   155 │         AccountHeader header = 1;
       ·         ──────┬──────
       ·               ╰── found here
   156 │ 
       ╰────

  Error: 
    × name 'Digest' is not defined
       ╭─[store/rpc.proto:194:13]
   193 │             // a `Word` representing the commitment
   194 │             Digest commitment = 2;
       ·             ───┬──
       ·                ╰── found here
   195 │         }
       ╰────

make: *** [Makefile:88: build] Error 101

```