### PR TITLE
feat: optimize `GetAccountProof` for small accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 ## v0.11.2 (2025-09-10)
 
 - Added support for keepalive requests against base path `/` of RPC server ([#1212](https://github.com/0xMiden/miden-node/pull/1212)).
+- [BREAKING] Replace `GetAccountProofs` with `GetAccountProof` in the public store API ([#1211](https://github.com/0xMiden/miden-node/pull/1211)).
+- [BREAKING] Optimize `GetAccountProof` for small accounts ([#1185](https://github.com/0xMiden/miden-node/pull/1185)).
 
 ## v0.11.1 (2025-09-08)
 

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -349,7 +349,7 @@ impl AccountVaultDetails {
     const MAX_RETURN_ENTRIES: usize = 1000;
 
     pub fn new(vault: &AssetVault) -> Self {
-        if vault.assets().skip(Self::MAX_RETURN_ENTRIES).next().is_some() {
+        if vault.assets().nth(Self::MAX_RETURN_ENTRIES).is_some() {
             Self::too_many()
         } else {
             Self {

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -163,7 +163,6 @@ impl TryFrom<proto::rpc_store::account_proof_request::AccountDetailRequest>
     }
 }
 
-/// Represents a request for an account's storage map values and its proof of existence.
 impl TryFrom<proto::account::AccountStorageHeader> for AccountStorageHeader {
     type Error = ConversionError;
 

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -348,7 +348,7 @@ impl AccountVaultDetails {
     const MAX_RETURN_ENTRIES: usize = 1000;
 
     pub fn new(vault: &AssetVault) -> Self {
-        if vault.asset_tree().num_leaves() > Self::MAX_RETURN_ENTRIES {
+        if vault.assets().skip(Self::MAX_RETURN_ENTRIES).next().is_some() {
             Self {
                 too_many_assets: true,
                 assets: Vec::new(),

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -206,8 +206,18 @@ impl TryFrom<proto::rpc_store::account_storage_details::AccountStorageMapDetails
                 .entries
                 .into_iter()
                 .map(|entry| {
-                    let key = entry.key.ok_or(ConversionError::NotAValidFelt)?.try_into()?;
-                    let value = entry.value.ok_or(ConversionError::NotAValidFelt)?.try_into()?;
+                    let key = entry
+                        .key
+                        .ok_or(proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry::missing_field(
+                            stringify!(key),
+                        ))?
+                        .try_into()?;
+                    let value = entry
+                        .value
+                        .ok_or(proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry::missing_field(
+                            stringify!(value),
+                        ))?
+                        .try_into()?;
                     Ok((key, value))
                 })
                 .collect::<Result<Vec<_>, ConversionError>>()?,

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -435,7 +435,7 @@ const fn storage_slot_type_to_raw(slot_type: StorageSlotType) -> u32 {
 }
 
 /// Represents account details returned in response to an account proof request.
-pub struct AccountDetailsResponse {
+pub struct AccountDetails {
     pub account_header: AccountHeader,
     pub account_code: Option<Vec<u8>>,
     pub vault_details: AccountVaultDetails,
@@ -445,7 +445,7 @@ pub struct AccountDetailsResponse {
 /// Represents the response to an account proof request.
 pub struct AccountProofResponse {
     pub witness: AccountWitness,
-    pub details: Option<AccountDetailsResponse>,
+    pub details: Option<AccountDetails>,
 }
 
 impl TryFrom<proto::rpc_store::AccountProofResponse> for AccountProofResponse {
@@ -475,15 +475,13 @@ impl From<AccountProofResponse> for proto::rpc_store::AccountProofResponse {
     }
 }
 
-impl TryFrom<proto::rpc_store::account_proof_response::AccountDetailsResponse>
-    for AccountDetailsResponse
-{
+impl TryFrom<proto::rpc_store::account_proof_response::AccountDetails> for AccountDetails {
     type Error = ConversionError;
 
     fn try_from(
-        value: proto::rpc_store::account_proof_response::AccountDetailsResponse,
+        value: proto::rpc_store::account_proof_response::AccountDetails,
     ) -> Result<Self, Self::Error> {
-        let proto::rpc_store::account_proof_response::AccountDetailsResponse {
+        let proto::rpc_store::account_proof_response::AccountDetails {
             header,
             code,
             vault_details,
@@ -491,31 +489,25 @@ impl TryFrom<proto::rpc_store::account_proof_response::AccountDetailsResponse>
         } = value;
 
         let account_header = header
-            .ok_or(
-                proto::rpc_store::account_proof_response::AccountDetailsResponse::missing_field(
-                    stringify!(header),
-                ),
-            )?
+            .ok_or(proto::rpc_store::account_proof_response::AccountDetails::missing_field(
+                stringify!(header),
+            ))?
             .try_into()?;
 
         let vault_details = vault_details
-            .ok_or(
-                proto::rpc_store::account_proof_response::AccountDetailsResponse::missing_field(
-                    stringify!(vault_details),
-                ),
-            )?
+            .ok_or(proto::rpc_store::account_proof_response::AccountDetails::missing_field(
+                stringify!(vault_details),
+            ))?
             .try_into()?;
         let account_code = code;
 
         let storage_details = storage_details
-            .ok_or(
-                proto::rpc_store::account_proof_response::AccountDetailsResponse::missing_field(
-                    stringify!(storage_details),
-                ),
-            )?
+            .ok_or(proto::rpc_store::account_proof_response::AccountDetails::missing_field(
+                stringify!(storage_details),
+            ))?
             .try_into()?;
 
-        Ok(AccountDetailsResponse {
+        Ok(AccountDetails {
             account_header,
             account_code,
             vault_details,
@@ -524,11 +516,9 @@ impl TryFrom<proto::rpc_store::account_proof_response::AccountDetailsResponse>
     }
 }
 
-impl From<AccountDetailsResponse>
-    for proto::rpc_store::account_proof_response::AccountDetailsResponse
-{
-    fn from(value: AccountDetailsResponse) -> Self {
-        let AccountDetailsResponse {
+impl From<AccountDetails> for proto::rpc_store::account_proof_response::AccountDetails {
+    fn from(value: AccountDetails) -> Self {
+        let AccountDetails {
             account_header,
             account_code,
             storage_details,

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -556,18 +556,18 @@ impl TryFrom<proto::rpc_store::account_proof_response::AccountDetails> for Accou
             ))?
             .try_into()?;
 
+        let storage_details = storage_details
+            .ok_or(proto::rpc_store::account_proof_response::AccountDetails::missing_field(
+                stringify!(storage_details),
+            ))?
+            .try_into()?;
+
         let vault_details = vault_details
             .ok_or(proto::rpc_store::account_proof_response::AccountDetails::missing_field(
                 stringify!(vault_details),
             ))?
             .try_into()?;
         let account_code = code;
-
-        let storage_details = storage_details
-            .ok_or(proto::rpc_store::account_proof_response::AccountDetails::missing_field(
-                stringify!(storage_details),
-            ))?
-            .try_into()?;
 
         Ok(AccountDetails {
             account_header,
@@ -582,21 +582,21 @@ impl From<AccountDetails> for proto::rpc_store::account_proof_response::AccountD
     fn from(value: AccountDetails) -> Self {
         let AccountDetails {
             account_header,
-            account_code,
             storage_details,
+            account_code,
             vault_details,
         } = value;
 
         let header = Some(proto::account::AccountHeader::from(account_header));
+        let storage_details = Some(storage_details.into());
         let code = account_code;
         let vault_details = Some(vault_details.into());
-        let storage_details = Some(storage_details.into());
 
         Self {
             header,
+            storage_details,
             code,
             vault_details,
-            storage_details,
         }
     }
 }

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -105,75 +105,174 @@ impl From<&AccountInfo> for proto::account::AccountDetails {
 /// Represents a request for an account proof.
 pub struct AccountProofRequest {
     pub account_id: AccountId,
-    pub account_details: Option<AccountDetailRequest>,
+    pub block_num: BlockNumber,
+    pub details: Option<AccountDetailRequest>,
 }
 
 impl TryFrom<proto::rpc_store::AccountProofRequest> for AccountProofRequest {
     type Error = ConversionError;
 
-    fn try_from(request: proto::rpc_store::AccountProofRequest) -> Result<Self, Self::Error> {
-        let proto::rpc_store::AccountProofRequest { account_id, account_details } = request;
+    fn try_from(value: proto::rpc_store::AccountProofRequest) -> Result<Self, Self::Error> {
+        let proto::rpc_store::AccountProofRequest { account_id, block_num, details } = value;
 
         let account_id = account_id
             .ok_or(proto::rpc_store::AccountProofRequest::missing_field(stringify!(account_id)))?
             .try_into()?;
 
-        let account_details = account_details.map(TryFrom::try_from).transpose()?;
+        let details = details.map(TryFrom::try_from).transpose()?;
 
-        Ok(AccountProofRequest { account_id, account_details })
+        Ok(AccountProofRequest {
+            account_id,
+            block_num: block_num.into(),
+            details,
+        })
     }
 }
 
 /// Represents a request for account details alongside specific storage data.
 pub struct AccountDetailRequest {
     pub code_commitment: Option<Word>,
-    pub storage_requests: Vec<StorageMapKeysProof>,
+    pub storage_requests: Vec<StorageMapRequest>,
+    pub include_assets: bool,
 }
 
-impl TryFrom<proto::rpc_store::account_proof_request::AccountDetailsRequest>
+impl TryFrom<proto::rpc_store::account_proof_request::AccountDetailRequest>
     for AccountDetailRequest
 {
     type Error = ConversionError;
 
     fn try_from(
-        request: proto::rpc_store::account_proof_request::AccountDetailsRequest,
+        value: proto::rpc_store::account_proof_request::AccountDetailRequest,
     ) -> Result<Self, Self::Error> {
-        let proto::rpc_store::account_proof_request::AccountDetailsRequest {
+        let proto::rpc_store::account_proof_request::AccountDetailRequest {
+            code_commitment,
+            storage_maps,
+            include_assets,
+        } = value;
+
+        let code_commitment = code_commitment.map(TryFrom::try_from).transpose()?;
+        let storage_requests = try_convert(storage_maps).collect::<Result<_, _>>()?;
+
+        Ok(AccountDetailRequest {
             code_commitment,
             storage_requests,
-        } = request;
-
-        let storage_requests = try_convert(storage_requests).collect::<Result<_, _>>()?;
-        let code_commitment = code_commitment.map(Word::try_from).transpose()?;
-
-        Ok(AccountDetailRequest { code_commitment, storage_requests })
+            include_assets,
+        })
     }
 }
 
 /// Represents a request for an account's storage map values and its proof of existence.
-pub struct StorageMapKeysProof {
-    /// Index of the storage map
-    pub storage_index: u8,
-    /// List of requested keys in the map
-    pub storage_keys: Vec<Word>,
+impl TryFrom<proto::account::AccountStorageHeader> for AccountStorageHeader {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::account::AccountStorageHeader) -> Result<Self, Self::Error> {
+        let proto::account::AccountStorageHeader { slots } = value;
+
+        // Convert slots to AccountStorageHeader format
+        // This is a simplified conversion - adjust based on actual requirements
+        let items = slots
+            .into_iter()
+            .map(|slot| {
+                let slot_type = storage_slot_type_from_raw(slot.slot_type)?;
+                let commitment =
+                    slot.commitment.ok_or(ConversionError::NotAValidFelt)?.try_into()?;
+                Ok((slot_type, commitment))
+            })
+            .collect::<Result<Vec<_>, ConversionError>>()?;
+
+        // Create AccountStorageHeader from the items
+        // Note: This might need adjustment based on the actual AccountStorageHeader constructor
+        Ok(AccountStorageHeader::new(items))
+    }
 }
 
-impl TryFrom<proto::rpc_store::account_proof_request::account_details_request::StorageRequest>
-    for StorageMapKeysProof
+impl TryFrom<proto::rpc_store::account_storage_details::AccountStorageMapDetails>
+    for AccountStorageMapDetails
 {
     type Error = ConversionError;
 
     fn try_from(
-        request: proto::rpc_store::account_proof_request::account_details_request::StorageRequest,
+        value: proto::rpc_store::account_storage_details::AccountStorageMapDetails,
     ) -> Result<Self, Self::Error> {
-        let proto::rpc_store::account_proof_request::account_details_request::StorageRequest {
-            storage_slot_index,
-            map_keys,
-        } = request;
+        let proto::rpc_store::account_storage_details::AccountStorageMapDetails {
+            slot_index,
+            too_many_entries,
+            entries,
+        } = value;
 
-        Ok(StorageMapKeysProof {
-            storage_index: storage_slot_index.try_into()?,
-            storage_keys: try_convert(map_keys).collect::<Result<_, _>>()?,
+        let slot_index = slot_index.try_into().map_err(ConversionError::TryFromIntError)?;
+
+        // Extract map_entries from the entries field
+        let map_entries = match entries {
+            Some(entries) => entries
+                .entries
+                .into_iter()
+                .map(|entry| {
+                    let key = entry.key.ok_or(ConversionError::NotAValidFelt)?.try_into()?;
+                    let value = entry.value.ok_or(ConversionError::NotAValidFelt)?.try_into()?;
+                    Ok((key, value))
+                })
+                .collect::<Result<Vec<_>, ConversionError>>()?,
+            None => Vec::new(),
+        };
+
+        Ok(Self {
+            slot_index,
+            too_many_entries,
+            map_entries,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageMapRequest {
+    pub slot_index: u8,
+    pub slot_data: SlotData,
+}
+
+impl
+    TryFrom<
+        proto::rpc_store::account_proof_request::account_detail_request::StorageMapDetailRequest,
+    > for StorageMapRequest
+{
+    type Error = ConversionError;
+
+    fn try_from(
+        value: proto::rpc_store::account_proof_request::account_detail_request::StorageMapDetailRequest,
+    ) -> Result<Self, Self::Error> {
+        let proto::rpc_store::account_proof_request::account_detail_request::StorageMapDetailRequest {
+            slot_index,
+            slot_data,
+        } = value;
+
+        let slot_index = slot_index.try_into()?;
+        let slot_data = slot_data.ok_or(proto::rpc_store::account_proof_request::account_detail_request::StorageMapDetailRequest::missing_field(stringify!(slot_data)))?.try_into()?;
+
+        Ok(StorageMapRequest { slot_index, slot_data })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlotData {
+    All,
+    MapKeys(Vec<Word>),
+}
+
+impl TryFrom<proto::rpc_store::account_proof_request::account_detail_request::storage_map_detail_request::SlotData>
+    for SlotData
+{
+    type Error = ConversionError;
+
+    fn try_from(value: proto::rpc_store::account_proof_request::account_detail_request::storage_map_detail_request::SlotData) -> Result<Self, Self::Error> {
+        use proto::rpc_store::account_proof_request::account_detail_request::storage_map_detail_request::SlotData as ProtoSlotData;
+
+        Ok(match value {
+            ProtoSlotData::AllEntries(true) => SlotData::All,
+            ProtoSlotData::AllEntries(false) => return Err(ConversionError::EnumDiscriminantOutOfRange),
+            ProtoSlotData::MapKeys(keys) => {
+                let keys = try_convert(keys.map_keys).collect::<Result<Vec<_>, _>>()?;
+                SlotData::MapKeys(keys)
+            },
         })
     }
 }
@@ -243,6 +342,83 @@ impl From<AccountStorageHeader> for proto::account::AccountStorageHeader {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountVaultDetails {
+    pub too_many_assets: bool,
+    pub assets: Vec<Asset>,
+}
+
+impl TryFrom<proto::rpc_store::AccountVaultDetails> for AccountVaultDetails {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::rpc_store::AccountVaultDetails) -> Result<Self, Self::Error> {
+        let proto::rpc_store::AccountVaultDetails { too_many_assets, assets } = value;
+
+        let assets =
+            Result::<Vec<_>, ConversionError>::from_iter(assets.into_iter().map(|asset| {
+                let asset = asset
+                    .asset
+                    .ok_or(proto::primitives::Asset::missing_field(stringify!(asset)))?;
+                let asset = Word::try_from(asset)?;
+                Asset::try_from(asset).map_err(ConversionError::AssetError)
+            }))?;
+        Ok(Self { too_many_assets, assets })
+    }
+}
+
+impl From<AccountVaultDetails> for proto::rpc_store::AccountVaultDetails {
+    fn from(value: AccountVaultDetails) -> Self {
+        let AccountVaultDetails { too_many_assets, assets } = value;
+
+        Self {
+            too_many_assets,
+            assets: Vec::from_iter(assets.into_iter().map(|asset| proto::primitives::Asset {
+                asset: Some(proto::primitives::Digest::from(Word::from(asset))),
+            })),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountStorageMapDetails {
+    pub slot_index: u8,
+    pub too_many_entries: bool,
+    pub map_entries: Vec<(Word, Word)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountStorageDetails {
+    pub header: AccountStorageHeader,
+    pub map_details: Vec<AccountStorageMapDetails>,
+}
+
+impl TryFrom<proto::rpc_store::AccountStorageDetails> for AccountStorageDetails {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::rpc_store::AccountStorageDetails) -> Result<Self, Self::Error> {
+        let proto::rpc_store::AccountStorageDetails { header, map_details } = value;
+
+        let header = header
+            .ok_or(proto::rpc_store::AccountStorageDetails::missing_field(stringify!(header)))?
+            .try_into()?;
+
+        let map_details = try_convert(map_details).collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { header, map_details })
+    }
+}
+
+impl From<AccountStorageDetails> for proto::rpc_store::AccountStorageDetails {
+    fn from(value: AccountStorageDetails) -> Self {
+        let AccountStorageDetails { header, map_details } = value;
+
+        Self {
+            header: Some(header.into()),
+            map_details: map_details.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
 const fn storage_slot_type_from_raw(slot_type: u32) -> Result<StorageSlotType, ConversionError> {
     Ok(match slot_type {
         0 => StorageSlotType::Map,
@@ -261,164 +437,226 @@ const fn storage_slot_type_to_raw(slot_type: StorageSlotType) -> u32 {
 /// Represents account details returned in response to an account proof request.
 pub struct AccountDetailsResponse {
     pub account_header: AccountHeader,
-    pub storage_header: AccountStorageHeader,
     pub account_code: Option<Vec<u8>>,
-    pub storage_proofs: Vec<StorageSlotMapProof>,
+    pub vault_details: AccountVaultDetails,
+    pub storage_details: AccountStorageDetails,
 }
 
-impl TryFrom<proto::rpc_store::account_proof::AccountDetailsResponse> for AccountDetailsResponse {
+/// Represents the response to an account proof request.
+pub struct AccountProofResponse {
+    pub witness: AccountWitness,
+    pub details: Option<AccountDetailsResponse>,
+}
+
+impl TryFrom<proto::rpc_store::AccountProofResponse> for AccountProofResponse {
     type Error = ConversionError;
 
-    fn try_from(
-        value: proto::rpc_store::account_proof::AccountDetailsResponse,
-    ) -> Result<Self, Self::Error> {
-        let proto::rpc_store::account_proof::AccountDetailsResponse {
-            header,
-            storage_header,
-            account_code,
-            storage_maps,
-        } = value;
+    fn try_from(value: proto::rpc_store::AccountProofResponse) -> Result<Self, Self::Error> {
+        let proto::rpc_store::AccountProofResponse { witness, details } = value;
 
-        let account_header = header
-            .ok_or(proto::rpc_store::account_proof::AccountDetailsResponse::missing_field(
-                stringify!(header),
-            ))?
+        let witness = witness
+            .ok_or(proto::rpc_store::AccountProofResponse::missing_field(stringify!(witness)))?
             .try_into()?;
 
-        let storage_header = storage_header.ok_or(
-            proto::rpc_store::account_proof::AccountDetailsResponse::missing_field(stringify!(
-                storage_header
-            )),
-        )?;
+        let details = details.map(TryFrom::try_from).transpose()?;
 
-        let storage_header_entries = storage_header
-            .slots
-            .into_iter()
-            .map(|slot| {
-                let slot_type = storage_slot_type_from_raw(slot.slot_type)?;
-                let commitment = slot
-                    .commitment
-                    .ok_or(proto::account::account_storage_header::StorageSlot::missing_field(
-                        stringify!(commitment),
-                    ))?
-                    .try_into()?;
-                Ok((slot_type, commitment))
-            })
-            .collect::<Result<Vec<_>, ConversionError>>()?;
-
-        let storage_header = AccountStorageHeader::new(storage_header_entries);
-
-        let storage_proofs = try_convert(storage_maps).collect::<Result<_, _>>()?;
-
-        Ok(AccountDetailsResponse {
-            account_header,
-            storage_header,
-            account_code,
-            storage_proofs,
-        })
+        Ok(AccountProofResponse { witness, details })
     }
 }
 
-impl From<AccountDetailsResponse> for proto::rpc_store::account_proof::AccountDetailsResponse {
-    fn from(value: AccountDetailsResponse) -> Self {
-        let AccountDetailsResponse {
-            account_header,
-            storage_header,
-            account_code,
-            storage_proofs,
-        } = value;
-
-        let header = Some(proto::account::AccountHeader::from(account_header));
-        let storage_header = Some(proto::account::AccountStorageHeader::from(storage_header));
-
-        let storage_maps = storage_proofs
-            .into_iter()
-            .map(|proof| {
-                let storage_slot = u32::from(proof.storage_slot);
-                let smt_proof = Some(proto::primitives::SmtOpening::from(proof.proof));
-                proto::rpc_store::account_proof::account_details_response::StorageSlotMapProof {
-                    storage_slot,
-                    smt_proof,
-                }
-            })
-            .collect();
+impl From<AccountProofResponse> for proto::rpc_store::AccountProofResponse {
+    fn from(value: AccountProofResponse) -> Self {
+        let AccountProofResponse { witness, details } = value;
 
         Self {
-            header,
-            storage_header,
-            account_code,
-            storage_maps,
+            witness: Some(witness.into()),
+            details: details.map(Into::into),
         }
     }
 }
 
-/// Represents a storage slot map proof.
-pub struct StorageSlotMapProof {
-    pub storage_slot: u8,
-    pub proof: miden_objects::crypto::merkle::SmtProof,
-}
-
-impl TryFrom<proto::rpc_store::account_proof::account_details_response::StorageSlotMapProof>
-    for StorageSlotMapProof
+impl TryFrom<proto::rpc_store::account_proof_response::AccountDetailsResponse>
+    for AccountDetailsResponse
 {
     type Error = ConversionError;
 
     fn try_from(
-        proof: proto::rpc_store::account_proof::account_details_response::StorageSlotMapProof,
+        value: proto::rpc_store::account_proof_response::AccountDetailsResponse,
     ) -> Result<Self, Self::Error> {
-        let proto::rpc_store::account_proof::account_details_response::StorageSlotMapProof {
-            storage_slot,
-            smt_proof,
-        } = proof;
+        let proto::rpc_store::account_proof_response::AccountDetailsResponse {
+            header,
+            code,
+            vault_details,
+            storage_details,
+        } = value;
 
-        let storage_slot = storage_slot.try_into().map_err(ConversionError::TryFromIntError)?;
-        let proof =
-        smt_proof.ok_or(proto::rpc_store::account_proof::account_details_response::StorageSlotMapProof::missing_field(stringify!(proof)))?.try_into()?;
+        let account_header = header
+            .ok_or(
+                proto::rpc_store::account_proof_response::AccountDetailsResponse::missing_field(
+                    stringify!(header),
+                ),
+            )?
+            .try_into()?;
 
-        Ok(StorageSlotMapProof { storage_slot, proof })
-    }
-}
+        let vault_details = vault_details
+            .ok_or(
+                proto::rpc_store::account_proof_response::AccountDetailsResponse::missing_field(
+                    stringify!(vault_details),
+                ),
+            )?
+            .try_into()?;
+        let account_code = code;
 
-// ACCOUNT PROOF
-// ================================================================================================
+        let storage_details = storage_details
+            .ok_or(
+                proto::rpc_store::account_proof_response::AccountDetailsResponse::missing_field(
+                    stringify!(storage_details),
+                ),
+            )?
+            .try_into()?;
 
-/// Represents an account proof.
-pub struct AccountProofResponse {
-    pub block_num: BlockNumber,
-    pub witness: AccountWitnessRecord,
-    pub account_details: Option<AccountDetailsResponse>,
-}
-
-impl TryFrom<proto::rpc_store::AccountProof> for AccountProofResponse {
-    type Error = ConversionError;
-
-    fn try_from(proof: proto::rpc_store::AccountProof) -> Result<Self, Self::Error> {
-        let proto::rpc_store::AccountProof { block_num, witness, details } = proof;
-
-        let witness =
-            witness.ok_or(proto::rpc_store::AccountProof::missing_field(stringify!(witness)))?;
-
-        let witness = AccountWitnessRecord::try_from(witness)?;
-
-        let account_details = details.map(AccountDetailsResponse::try_from).transpose()?;
-
-        Ok(AccountProofResponse {
-            block_num: block_num.into(),
-            witness,
-            account_details,
+        Ok(AccountDetailsResponse {
+            account_header,
+            account_code,
+            vault_details,
+            storage_details,
         })
     }
 }
 
-impl From<AccountProofResponse> for proto::rpc_store::AccountProof {
-    fn from(value: AccountProofResponse) -> Self {
-        let AccountProofResponse { block_num, witness, account_details } = value;
+impl From<AccountDetailsResponse>
+    for proto::rpc_store::account_proof_response::AccountDetailsResponse
+{
+    fn from(value: AccountDetailsResponse) -> Self {
+        let AccountDetailsResponse {
+            account_header,
+            account_code,
+            storage_details,
+            vault_details,
+        } = value;
 
-        proto::rpc_store::AccountProof {
-            block_num: block_num.as_u32(),
-            witness: Some(proto::account::AccountWitness::from(witness)),
-            details: account_details
-                .map(proto::rpc_store::account_proof::AccountDetailsResponse::from),
+        let header = Some(proto::account::AccountHeader::from(account_header));
+        let code = account_code;
+        let vault_details = Some(vault_details.into());
+        let storage_details = Some(storage_details.into());
+
+        Self {
+            header,
+            code,
+            vault_details,
+            storage_details,
+        }
+    }
+}
+
+// ACCOUNT PROOF
+impl From<AccountStorageMapDetails>
+    for proto::rpc_store::account_storage_details::AccountStorageMapDetails
+{
+    fn from(value: AccountStorageMapDetails) -> Self {
+        let AccountStorageMapDetails {
+            slot_index,
+            too_many_entries,
+            map_entries,
+        } = value;
+
+        // Create the entries wrapped in MapEntries message
+        let entries = proto::rpc_store::account_storage_details::account_storage_map_details::MapEntries {
+            entries: map_entries
+                .into_iter()
+                .map(|(key, value)| {
+                    proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry {
+                        key: Some(key.into()),
+                        value: Some(value.into()),
+                    }
+                })
+                .collect(),
+        };
+
+        Self {
+            slot_index: u32::from(slot_index),
+            too_many_entries,
+            entries: Some(entries),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StorageMapEntry {
+    pub key: Word,
+    pub value: Word,
+}
+
+impl
+    TryFrom<proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry>
+    for StorageMapEntry
+{
+    type Error = ConversionError;
+
+    fn try_from(
+        value: proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry,
+    ) -> Result<Self, Self::Error> {
+        let proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry {
+            key,
+            value
+        } = value;
+
+        Ok(Self {
+            key: key.ok_or(proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry::missing_field(stringify!(key)))?.try_into()?,
+            value: value.ok_or(proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry::missing_field(stringify!(value)))?.try_into()?,
+        })
+    }
+}
+
+impl From<StorageMapEntry>
+    for proto::rpc_store::account_storage_details::account_storage_map_details::map_entries::StorageMapEntry
+{
+    fn from(value: StorageMapEntry) -> Self {
+        let StorageMapEntry { key, value } = value;
+
+        Self {
+            key: Some(proto::primitives::Digest::from(key)),
+            value: Some(proto::primitives::Digest::from(value)),
+        }
+    }
+}
+
+// ACCOUNT WITNESS
+// ================================================================================================
+
+impl TryFrom<proto::account::AccountWitness> for AccountWitness {
+    type Error = ConversionError;
+
+    fn try_from(account_witness: proto::account::AccountWitness) -> Result<Self, Self::Error> {
+        let witness_id = account_witness
+            .witness_id
+            .ok_or(proto::account::AccountWitness::missing_field(stringify!(witness_id)))?
+            .try_into()?;
+        let commitment = account_witness
+            .commitment
+            .ok_or(proto::account::AccountWitness::missing_field(stringify!(commitment)))?
+            .try_into()?;
+        let path = account_witness
+            .path
+            .ok_or(proto::account::AccountWitness::missing_field(stringify!(path)))?
+            .try_into()?;
+
+        AccountWitness::new(witness_id, commitment, path).map_err(|err| {
+            ConversionError::deserialization_error(
+                "AccountWitness",
+                DeserializationError::InvalidValue(err.to_string()),
+            )
+        })
+    }
+}
+
+impl From<AccountWitness> for proto::account::AccountWitness {
+    fn from(witness: AccountWitness) -> Self {
+        Self {
+            account_id: Some(witness.id().into()),
+            witness_id: Some(witness.id().into()),
+            commitment: Some(witness.state_commitment().into()),
+            path: Some(witness.into_proof().into_parts().0.into()),
         }
     }
 }
@@ -426,7 +664,7 @@ impl From<AccountProofResponse> for proto::rpc_store::AccountProof {
 // ACCOUNT WITNESS RECORD
 // ================================================================================================
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AccountWitnessRecord {
     pub account_id: AccountId,
     pub witness: AccountWitness,

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -169,8 +169,6 @@ impl TryFrom<proto::account::AccountStorageHeader> for AccountStorageHeader {
     fn try_from(value: proto::account::AccountStorageHeader) -> Result<Self, Self::Error> {
         let proto::account::AccountStorageHeader { slots } = value;
 
-        // Convert slots to AccountStorageHeader format
-        // This is a simplified conversion - adjust based on actual requirements
         let items = slots
             .into_iter()
             .map(|slot| {
@@ -181,8 +179,6 @@ impl TryFrom<proto::account::AccountStorageHeader> for AccountStorageHeader {
             })
             .collect::<Result<Vec<_>, ConversionError>>()?;
 
-        // Create AccountStorageHeader from the items
-        // Note: This might need adjustment based on the actual AccountStorageHeader constructor
         Ok(AccountStorageHeader::new(items))
     }
 }

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -10,7 +10,7 @@ use miden_objects::account::{
     StorageMap,
     StorageSlotType,
 };
-use miden_objects::asset::Asset;
+use miden_objects::asset::{Asset, AssetVault};
 use miden_objects::block::{AccountWitness, BlockNumber};
 use miden_objects::note::{NoteExecutionMode, NoteTag};
 use miden_objects::utils::{Deserializable, DeserializationError, Serializable};
@@ -347,6 +347,29 @@ impl From<AccountStorageHeader> for proto::account::AccountStorageHeader {
 pub struct AccountVaultDetails {
     pub too_many_assets: bool,
     pub assets: Vec<Asset>,
+}
+impl AccountVaultDetails {
+    const MAX_RETURN_ENTRIES: usize = 1000;
+
+    pub fn new(vault: &AssetVault) -> Self {
+        if vault.asset_tree().num_leaves() > Self::MAX_RETURN_ENTRIES {
+            Self {
+                too_many_assets: true,
+                assets: Vec::new(),
+            }
+        } else {
+            Self {
+                too_many_assets: false,
+                assets: Vec::from_iter(vault.assets()),
+            }
+        }
+    }
+    pub fn too_many() -> Self {
+        Self {
+            too_many_assets: false,
+            assets: Vec::new(),
+        }
+    }
 }
 
 impl TryFrom<proto::rpc_store::AccountVaultDetails> for AccountVaultDetails {

--- a/crates/proto/src/generated/rpc.rs
+++ b/crates/proto/src/generated/rpc.rs
@@ -181,7 +181,7 @@ pub mod api_client {
                 super::super::rpc_store::AccountProofRequest,
             >,
         ) -> std::result::Result<
-            tonic::Response<super::super::rpc_store::AccountProof>,
+            tonic::Response<super::super::rpc_store::AccountProofResponse>,
             tonic::Status,
         > {
             self.inner
@@ -564,7 +564,7 @@ pub mod api_server {
             &self,
             request: tonic::Request<super::super::rpc_store::AccountProofRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::super::rpc_store::AccountProof>,
+            tonic::Response<super::super::rpc_store::AccountProofResponse>,
             tonic::Status,
         >;
         /// Returns raw block data for the specified block number.
@@ -916,7 +916,7 @@ pub mod api_server {
                     > tonic::server::UnaryService<
                         super::super::rpc_store::AccountProofRequest,
                     > for GetAccountProofSvc<T> {
-                        type Response = super::super::rpc_store::AccountProof;
+                        type Response = super::super::rpc_store::AccountProofResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -144,9 +144,9 @@ pub mod account_storage_details {
         /// slot index of the storage map
         #[prost(uint32, tag = "1")]
         pub slot_index: u32,
-        /// A flag that is set to true if all_entries == true was used in the request for this
-        /// storage map and the map contains too many entries. This indicates to the user
-        /// that `SyncStorageMaps` endpoint should be used to get all storage map data
+        /// A flag that is set to `true` if the number of to-be-returned entries in the
+        /// storage map would exceed a threshold. This indicates to the user that `SyncStorageMaps`
+        /// endpoint should be used to get all storage map data.
         #[prost(bool, tag = "2")]
         pub too_many_entries: bool,
         /// By default we provide all storage entries.

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -34,12 +34,14 @@ pub mod account_proof_request {
         /// only if its commitment is different from this value or if the value is not present.
         #[prost(message, optional, tag = "1")]
         pub code_commitment: ::core::option::Option<super::super::primitives::Digest>,
-        /// A flag indicating whether to include asset vault data.
-        ///
+        /// Last known asset vault commitment to the client. The response will include asset vault data
+        /// only if its commitment is different from this value or if the value is not present.
         /// Assets will only be returned for small accounts with less than 100 asset entries,
         /// otherwise they have to be requested separately.
-        #[prost(bool, tag = "2")]
-        pub include_assets: bool,
+        #[prost(message, optional, tag = "2")]
+        pub asset_vault_commitment: ::core::option::Option<
+            super::super::primitives::Digest,
+        >,
         /// Additional request per storage map.
         #[prost(message, repeated, tag = "3")]
         pub storage_maps: ::prost::alloc::vec::Vec<

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -36,8 +36,8 @@ pub mod account_proof_request {
         pub code_commitment: ::core::option::Option<super::super::primitives::Digest>,
         /// Last known asset vault commitment to the client. The response will include asset vault data
         /// only if its commitment is different from this value or if the value is not present.
-        /// Assets will only be returned for small accounts with less than 100 asset entries,
-        /// otherwise they have to be requested separately.
+        /// If the number of to-be-returned asset entries exceed a threshold, they have to be requested
+        /// separately, which is signaled in the response message.
         #[prost(message, optional, tag = "2")]
         pub asset_vault_commitment: ::core::option::Option<
             super::super::primitives::Digest,

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -100,15 +100,15 @@ pub mod account_proof_response {
         /// Account header.
         #[prost(message, optional, tag = "1")]
         pub header: ::core::option::Option<super::super::account::AccountHeader>,
-        /// Account code; empty if code commitments matched
-        #[prost(bytes = "vec", optional, tag = "2")]
+        /// Account storage data
+        #[prost(message, optional, tag = "2")]
+        pub storage_details: ::core::option::Option<super::AccountStorageDetails>,
+        /// Account code; empty if code commitments matched or none was requested
+        #[prost(bytes = "vec", optional, tag = "3")]
         pub code: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
         /// Account asset vault data; empty if vault commitments matched
-        #[prost(message, optional, tag = "3")]
-        pub vault_details: ::core::option::Option<super::AccountVaultDetails>,
-        /// Account storage data; empty if storage commitments matched
         #[prost(message, optional, tag = "4")]
-        pub storage_details: ::core::option::Option<super::AccountStorageDetails>,
+        pub vault_details: ::core::option::Option<super::AccountVaultDetails>,
     }
 }
 /// Account vault details for AccountProofResponse

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -93,12 +93,12 @@ pub struct AccountProofResponse {
     pub witness: ::core::option::Option<super::account::AccountWitness>,
     /// Additional details for public accounts
     #[prost(message, optional, tag = "2")]
-    pub details: ::core::option::Option<account_proof_response::AccountDetailsResponse>,
+    pub details: ::core::option::Option<account_proof_response::AccountDetails>,
 }
 /// Nested message and enum types in `AccountProofResponse`.
 pub mod account_proof_response {
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct AccountDetailsResponse {
+    pub struct AccountDetails {
         /// Account header.
         #[prost(message, optional, tag = "1")]
         pub header: ::core::option::Option<super::super::account::AccountHeader>,

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -35,9 +35,10 @@ pub mod account_proof_request {
         #[prost(message, optional, tag = "1")]
         pub code_commitment: ::core::option::Option<super::super::primitives::Digest>,
         /// Last known asset vault commitment to the client. The response will include asset vault data
-        /// only if its commitment is different from this value or if the value is not present.
+        /// only if its commitment is different from this value. If the value is not present in the
+        /// request, the response will not contain one either.
         /// If the number of to-be-returned asset entries exceed a threshold, they have to be requested
-        /// separately, which is signaled in the response message.
+        /// separately, which is signaled in the response message with dedicated flag.
         #[prost(message, optional, tag = "2")]
         pub asset_vault_commitment: ::core::option::Option<
             super::super::primitives::Digest,

--- a/crates/proto/src/generated/rpc_store.rs
+++ b/crates/proto/src/generated/rpc_store.rs
@@ -31,18 +31,13 @@ pub mod account_proof_request {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountDetailRequest {
         /// Last known code commitment to the client. The response will include account code
-        /// only if its commitment is different from this value.
-        ///
-        /// We could also extend this methodology to account storage and asset vault to return
-        /// data only if the client doesn't already have it.
+        /// only if its commitment is different from this value or if the value is not present.
         #[prost(message, optional, tag = "1")]
         pub code_commitment: ::core::option::Option<super::super::primitives::Digest>,
-        /// A flag indicating whether the response should include asset vault data; assets
-        /// will be returned only if the account contains a small number of assets
-        /// (e.g., under 1000).
+        /// A flag indicating whether to include asset vault data.
         ///
-        /// We could also make this more granular and request assets under specific keys, but
-        /// I'm not sure this is needed at the moment.
+        /// Assets will only be returned for small accounts with less than 100 asset entries,
+        /// otherwise they have to be requested separately.
         #[prost(bool, tag = "2")]
         pub include_assets: bool,
         /// Additional request per storage map.
@@ -56,7 +51,7 @@ pub mod account_proof_request {
         /// Represents a storage slot index and the associated map keys.
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct StorageMapDetailRequest {
-            /// Storage slot index (\[0..255\])
+            /// Storage slot index (`\[0..255\]`).
             #[prost(uint32, tag = "1")]
             pub slot_index: u32,
             #[prost(oneof = "storage_map_detail_request::SlotData", tags = "2, 3")]
@@ -64,9 +59,10 @@ pub mod account_proof_request {
         }
         /// Nested message and enum types in `StorageMapDetailRequest`.
         pub mod storage_map_detail_request {
+            /// Indirection required for use in `oneof {..}` block.
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct MapKeys {
-                /// A list of map keys (Digests) associated with this storage slot.
+                /// A list of map keys associated with this storage slot.
                 #[prost(message, repeated, tag = "1")]
                 pub map_keys: ::prost::alloc::vec::Vec<
                     super::super::super::super::primitives::Digest,
@@ -74,11 +70,11 @@ pub mod account_proof_request {
             }
             #[derive(Clone, PartialEq, ::prost::Oneof)]
             pub enum SlotData {
-                /// A flag asking to return all storage map data; valid only for small storage maps
-                /// (e.g., with fewer than 1000 entries).
+                /// Request to return all storage map data. If the number exceeds a threshold of 1000 entries,
+                /// the response will not contain them but must be requested separately.
                 #[prost(bool, tag = "2")]
                 AllEntries(bool),
-                /// A list of map keys (Digests) associated with this storage slot.
+                /// A list of map keys associated with the given storage slot identified by `slot_index`.
                 #[prost(message, tag = "3")]
                 MapKeys(MapKeys),
             }

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -508,7 +508,7 @@ impl api_server::Api for RpcService {
     async fn get_account_proof(
         &self,
         request: Request<proto::rpc_store::AccountProofRequest>,
-    ) -> Result<Response<proto::rpc_store::AccountProof>, Status> {
+    ) -> Result<Response<proto::rpc_store::AccountProofResponse>, Status> {
         let request = request.into_inner();
 
         debug!(target: COMPONENT, ?request);

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -307,14 +307,14 @@ impl rpc_server::Rpc for StoreApi {
     async fn get_account_proof(
         &self,
         request: Request<proto::rpc_store::AccountProofRequest>,
-    ) -> Result<Response<proto::rpc_store::AccountProof>, Status> {
+    ) -> Result<Response<proto::rpc_store::AccountProofResponse>, Status> {
         debug!(target: COMPONENT, ?request);
         let request = request.into_inner();
-        let account_request = request.try_into()?;
+        let account_proof_request = request.try_into()?;
 
-        let proof = self.state.get_account_proof(account_request).await?;
+        let proof = self.state.get_account_proof(account_proof_request).await?;
 
-        Ok(Response::new(proto::rpc_store::AccountProof::from(proof)))
+        Ok(Response::new(proof.into()))
     }
 
     #[instrument(

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -23,7 +23,7 @@ use miden_node_proto::domain::account::{
 use miden_node_proto::domain::batch::BatchInputs;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::formatting::format_array;
-use miden_objects::account::{AccountHeader, AccountId, AccountStorageHeader, StorageSlot};
+use miden_objects::account::{AccountHeader, AccountId, StorageSlot};
 use miden_objects::block::{
     AccountTree,
     AccountWitness,

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -913,17 +913,10 @@ impl State {
                 return Err(DatabaseError::AccountNotPublic(account_id));
             };
 
-            let slot_headers = Vec::from_iter(
-                details
-                    .storage()
-                    .slots()
-                    .iter()
-                    .map(|storage_slot| (storage_slot.slot_type(), storage_slot.value())),
-            );
+            let storage_header = details.storage().to_header();
 
-            let storage_header = AccountStorageHeader::new(slot_headers);
-
-            let mut storage_map_details = Vec::<AccountStorageMapDetails>::new();
+            let mut storage_map_details =
+                Vec::<AccountStorageMapDetails>::with_capacity(storage_requests.len());
 
             for StorageMapRequest { slot_index, slot_data } in storage_requests {
                 let Some(StorageSlot::Map(storage_map)) =

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -914,7 +914,9 @@ impl State {
             let info = self.db.select_account(account_id).await?;
 
             // if we get a query for a private account, we'll return `None`
-            if let Some(details) = info.details {
+            let Some(details) = info.details else {
+                return Err(AccountError::StorageSlotNotMap(slot_index).into());
+            };
                 let slot_headers = Vec::from_iter(
                     details
                         .storage()

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -938,8 +938,7 @@ impl State {
             // Only include unknown account code blobs, which is equal to a account code digest
             // mismatch. If `None` was requested, don't return any.
             let account_code = code_commitment
-                .map(|code_commitment| code_commitment != details.code().commitment())
-                .unwrap_or(false)
+                .is_some_and(|code_commitment| code_commitment != details.code().commitment())
                 .then(|| details.code().to_bytes());
 
             // storage details

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use miden_node_proto::domain::account::{
     AccountDetailRequest,
-    AccountDetailsResponse,
+    AccountDetails,
     AccountInfo,
     AccountProofRequest,
     AccountProofResponse,
@@ -991,7 +991,7 @@ impl State {
                     }
                 };
 
-                Some(AccountDetailsResponse {
+                Some(AccountDetails {
                     account_header: AccountHeader::from(details),
                     account_code,
                     vault_details,

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -908,7 +908,7 @@ impl State {
         {
             let account_info = self.db.select_account(account_id).await?;
 
-            // if we get a query for a private account _with_ details requested, we'll error out
+            // if we get a query for a _private_ account _with_ details requested, we'll error out
             let Some(account) = account_info.details else {
                 return Err(DatabaseError::AccountNotPublic(account_id));
             };

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -952,7 +952,7 @@ impl State {
             // Similar to `code_commitment`, if the provided commitment matches, we don't return
             // vault data. If no commitment is provided or it doesn't match, we return
             // the vault data. If the number of vault contained assets are exceeding a
-            // limit, we signal this back in the reponse and the user must handle that
+            // limit, we signal this back in the response and the user must handle that
             // in follow-up request.
             let vault_details = match asset_vault_commitment {
                 Some(commitment) if commitment == details.vault().root() => {

--- a/crates/store/src/state.rs
+++ b/crates/store/src/state.rs
@@ -952,7 +952,7 @@ impl State {
                     AccountVaultDetails::empty()
                 },
                 Some(_) => {
-                    // Either no commitment provided or it doesn't match, so return vault data
+                    // The commitment doesn't match, so return vault data
                     AccountVaultDetails::new(details.vault())
                 },
                 None => {

--- a/proto/proto/rpc.proto
+++ b/proto/proto/rpc.proto
@@ -27,7 +27,7 @@ service Api {
     rpc GetAccountDetails(account.AccountId) returns (account.AccountDetails) {}
 
     // Returns the latest state proof of the specified account.
-    rpc GetAccountProof(rpc_store.AccountProofRequest) returns (rpc_store.AccountProof) {}
+    rpc GetAccountProof(rpc_store.AccountProofRequest) returns (rpc_store.AccountProofResponse) {}
 
     // Returns raw block data for the specified block number.
     rpc GetBlockByNumber(blockchain.BlockNumber) returns (blockchain.MaybeBlock) {}

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -158,14 +158,14 @@ message AccountProofResponse {
         // Account header.
         account.AccountHeader header = 1;
 
-        // Account code; empty if code commitments matched
-        optional bytes code = 2;
+        // Account storage data
+        AccountStorageDetails storage_details = 2;
+
+        // Account code; empty if code commitments matched or none was requested
+        optional bytes code = 3;
 
         // Account asset vault data; empty if vault commitments matched
-        optional AccountVaultDetails vault_details = 3;
-
-        // Account storage data; empty if storage commitments matched
-        optional AccountStorageDetails storage_details = 4;
+        optional AccountVaultDetails vault_details = 4;
     }
 
     // Account ID, current state commitment, and SMT path

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -204,9 +204,9 @@ message AccountStorageDetails {
         // slot index of the storage map
         uint32 slot_index = 1;
 
-        // A flag that is set to true if all_entries == true was used in the request for this
-        // storage map and the map contains too many entries. This indicates to the user
-        // that `SyncStorageMaps` endpoint should be used to get all storage map data
+        // A flag that is set to `true` if the number of to-be-returned entries in the
+        // storage map would exceed a threshold. This indicates to the user that `SyncStorageMaps`
+        // endpoint should be used to get all storage map data.
         bool too_many_entries = 2;
 
         // By default we provide all storage entries.

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -132,9 +132,10 @@ message AccountProofRequest {
         optional primitives.Digest code_commitment = 1;
 
         // Last known asset vault commitment to the client. The response will include asset vault data
-        // only if its commitment is different from this value or if the value is not present.
+        // only if its commitment is different from this value. If the value is not present in the
+        // request, the response will not contain one either.
         // If the number of to-be-returned asset entries exceed a threshold, they have to be requested
-        // separately, which is signaled in the response message.
+        // separately, which is signaled in the response message with dedicated flag.
         optional primitives.Digest asset_vault_commitment = 2;
 
         // Additional request per storage map.

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -109,36 +109,32 @@ message AccountProofRequest {
     message AccountDetailRequest {
         // Represents a storage slot index and the associated map keys.
         message StorageMapDetailRequest {
+            // Indirection required for use in `oneof {..}` block.
             message MapKeys {
-                // A list of map keys (Digests) associated with this storage slot.
+                // A list of map keys associated with this storage slot.
                 repeated primitives.Digest map_keys = 1;
             }
-            // Storage slot index ([0..255])
+            // Storage slot index (`[0..255]`).
             uint32 slot_index = 1;
 
             oneof slot_data {
-                // A flag asking to return all storage map data; valid only for small storage maps
-                // (e.g., with fewer than 1000 entries).
+                // Request to return all storage map data. If the number exceeds a threshold of 1000 entries,
+                // the response will not contain them but must be requested separately.
                 bool all_entries = 2;
 
-                // A list of map keys (Digests) associated with this storage slot.
+                // A list of map keys associated with the given storage slot identified by `slot_index`.
                 MapKeys map_keys = 3;
             }
         }
 
         // Last known code commitment to the client. The response will include account code
-        // only if its commitment is different from this value.
-        //
-        // We could also extend this methodology to account storage and asset vault to return
-        // data only if the client doesn't already have it.
-        primitives.Digest code_commitment = 1;
+        // only if its commitment is different from this value or if the value is not present.
+        optional primitives.Digest code_commitment = 1;
 
-        // A flag indicating whether the response should include asset vault data; assets
-        // will be returned only if the account contains a small number of assets
-        // (e.g., under 1000).
+        // A flag indicating whether to include asset vault data.
         //
-        // We could also make this more granular and request assets under specific keys, but
-        // I'm not sure this is needed at the moment.
+        // Assets will only be returned for small accounts with less than 100 asset entries,
+        // otherwise they have to be requested separately.
         bool include_assets = 2;
 
         // Additional request per storage map.

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -27,7 +27,7 @@ service Rpc {
     rpc GetAccountDetails(account.AccountId) returns (account.AccountDetails) {}
 
     // Returns the latest state proof of the specified account.
-    rpc GetAccountProof(AccountProofRequest) returns (AccountProof) {}
+    rpc GetAccountProof(AccountProofRequest) returns (AccountProofResponse) {}
 
     // Returns raw block data for the specified block number.
     rpc GetBlockByNumber(blockchain.BlockNumber) returns (blockchain.MaybeBlock) {}
@@ -103,70 +103,126 @@ message StoreStatus {
 // GET ACCOUNT PROOF
 // ================================================================================================
 
-// Returns the latest state proof of the specified accounts.
+// Returns the latest state proof of the specified account.
 message AccountProofRequest {
     // Request the details for a public account.
-    message AccountDetailsRequest {
+    message AccountDetailRequest {
         // Represents a storage slot index and the associated map keys.
-        message StorageRequest {
+        message StorageMapDetailRequest {
+            message MapKeys {
+                // A list of map keys (Digests) associated with this storage slot.
+                repeated primitives.Digest map_keys = 1;
+            }
             // Storage slot index ([0..255])
-            uint32 storage_slot_index = 1;
+            uint32 slot_index = 1;
 
-            // A list of map keys (Digests) associated with this storage slot.
-            repeated primitives.Digest map_keys = 2;
+            oneof slot_data {
+                // A flag asking to return all storage map data; valid only for small storage maps
+                // (e.g., with fewer than 1000 entries).
+                bool all_entries = 2;
+
+                // A list of map keys (Digests) associated with this storage slot.
+                MapKeys map_keys = 3;
+            }
         }
 
-        // Account code commitment corresponding to the last-known `AccountCode` for the requested
-        // account. The response will include only code that is known.
-        optional primitives.Digest code_commitment = 1;
+        // Last known code commitment to the client. The response will include account code
+        // only if its commitment is different from this value.
+        //
+        // We could also extend this methodology to account storage and asset vault to return
+        // data only if the client doesn't already have it.
+        primitives.Digest code_commitment = 1;
 
-        // List of storage requests for this account.
-        repeated StorageRequest storage_requests = 2;
+        // A flag indicating whether the response should include asset vault data; assets
+        // will be returned only if the account contains a small number of assets
+        // (e.g., under 1000).
+        //
+        // We could also make this more granular and request assets under specific keys, but
+        // I'm not sure this is needed at the moment.
+        bool include_assets = 2;
+
+        // Additional request per storage map.
+        repeated StorageMapDetailRequest storage_maps = 3;
     }
 
-    // The account ID for this request.
+    // ID of the account for which we want to get data
     account.AccountId account_id = 1;
 
-    // A account detail requests, including map keys + values.
-    optional AccountDetailsRequest account_details = 2;
+    // Block at which we'd like to get this data. Must be close to the chain tip.
+    fixed32 block_num = 2;
+
+    // Request for additional account details; valid only for public accounts.
+    optional AccountDetailRequest details = 3;
 }
 
-// Represents the result of getting account proofs.
-message AccountProof {
-    // State header, available for public accounts only.
+// Represents the result of getting account proof.
+message AccountProofResponse {
+
     message AccountDetailsResponse {
-        // Represents a single storage slot with the requested keys and their respective values.
-        message StorageSlotMapProof {
-            // The storage slot index ([0..255]).
-            uint32 storage_slot = 1;
-
-            // Merkle proof of the map value
-            primitives.SmtOpening smt_proof = 2;
-        }
-
-        // Account header, always included.
+        // Account header.
         account.AccountHeader header = 1;
 
-        // Account storage header containing slot types and commitments.
-        account.AccountStorageHeader storage_header = 2;
+        // Account code; empty if code commitments matched
+        optional bytes code = 2;
 
-        // Account code, if the current account code does not match the request provided commitment digest.
-        optional bytes account_code = 3;
+        // Account asset vault data; empty if vault commitments matched
+        optional AccountVaultDetails vault_details = 3;
 
-        // Storage slots information for this account
-        repeated StorageSlotMapProof storage_maps = 4;
+        // Account storage data; empty if storage commitments matched
+        optional AccountStorageDetails storage_details = 4;
     }
 
-    // Block number at which the state of the accounts is returned.
-    fixed32 block_num = 1;
+    // Account ID, current state commitment, and SMT path
+    account.AccountWitness witness = 1;
 
-    // The account witness for the current state commitment of one account ID.
-    account.AccountWitness witness = 2;
-
-    // State header for public accounts. Filled only if the flag `AccountDetailsRequest` was
-    // present and the account was a public account/the information was available.
-    optional AccountDetailsResponse details = 3;
+    // Additional details for public accounts
+    optional AccountDetailsResponse details = 2;
 }
+
+// Account vault details for AccountProofResponse
+message AccountVaultDetails {
+    // A flag that is set to true if the account contains too many assets. This indicates
+    // to the user that `SyncAccountVault` endpoint should be used to retrieve the
+    // account's assets
+    bool too_many_assets = 1;
+
+    // When too_many_assets == false, this will contain the list of assets in the
+    // account's vault
+    repeated primitives.Asset assets = 2;
+}
+
+// Account storage details for AccountProofResponse
+message AccountStorageDetails {
+    message AccountStorageMapDetails {
+        // Wrapper for repeated storage map entries
+        message MapEntries {
+            // Definition of individual storage entries.
+            message StorageMapEntry {
+                primitives.Digest key = 1;
+                primitives.Digest value = 2;
+            }
+
+            repeated StorageMapEntry entries = 1;
+        }
+        // slot index of the storage map
+        uint32 slot_index = 1;
+
+        // A flag that is set to true if all_entries == true was used in the request for this
+        // storage map and the map contains too many entries. This indicates to the user
+        // that `SyncStorageMaps` endpoint should be used to get all storage map data
+        bool too_many_entries = 2;
+
+        // By default we provide all storage entries.
+        MapEntries entries = 3;
+    }
+
+    // Account storage header (storage slot info for up to 256 slots)
+    account.AccountStorageHeader header = 1;
+
+    // Additional data for the requested storage maps
+    repeated AccountStorageMapDetails map_details = 2;
+}
+
 
 // CHECK NULLIFIERS
 // ================================================================================================

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -131,11 +131,11 @@ message AccountProofRequest {
         // only if its commitment is different from this value or if the value is not present.
         optional primitives.Digest code_commitment = 1;
 
-        // A flag indicating whether to include asset vault data.
-        //
-        // Assets will only be returned for small accounts with less than 100 asset entries,
-        // otherwise they have to be requested separately.
-        bool include_assets = 2;
+        // Last known asset vault commitment to the client. The response will include asset vault data
+        // only if its commitment is different from this value or if the value is not present.
+        // If the number of to-be-returned asset entries exceed a threshold, they have to be requested
+        // separately, which is signaled in the response message.
+        optional primitives.Digest asset_vault_commitment = 2;
 
         // Additional request per storage map.
         repeated StorageMapDetailRequest storage_maps = 3;

--- a/proto/proto/store/rpc.proto
+++ b/proto/proto/store/rpc.proto
@@ -158,7 +158,7 @@ message AccountProofRequest {
 // Represents the result of getting account proof.
 message AccountProofResponse {
 
-    message AccountDetailsResponse {
+    message AccountDetails {
         // Account header.
         account.AccountHeader header = 1;
 
@@ -176,7 +176,7 @@ message AccountProofResponse {
     account.AccountWitness witness = 1;
 
     // Additional details for public accounts
-    optional AccountDetailsResponse details = 2;
+    optional AccountDetails details = 2;
 }
 
 // Account vault details for AccountProofResponse


### PR DESCRIPTION
Part 2 of #1185 - reworks the `GetAccountProof` query with a new type.

The changeset focuses on providing account data / vault entries in the response if they are less than 100 (might be too conservative, for both). @SantiagoPittella 