### PR TITLE
fix(store): align account_storage_map_values PK with migration

### DIFF
--- a/crates/store/src/db/schema.rs
+++ b/crates/store/src/db/schema.rs
@@ -1,7 +1,7 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    account_storage_map_values (account_id, block_num, slot, key, is_latest_update) {
+    account_storage_map_values (account_id, block_num, slot, key) {
         account_id -> Binary,
         block_num -> BigInt,
         slot -> Integer,


### PR DESCRIPTION
The Diesel schema declared account_storage_map_values primary key as (account_id, block_num, slot, key, is_latest_update), but the authoritative SQL migration defines it as (account_id, block_num, slot, key). Including is_latest_update in the PK is incorrect: it’s a status flag used for toggling latest rows and is not part of the uniqueness constraint. This mismatch could cause Diesel to infer the wrong primary key shape, leading to incorrect query generation and violating the intended update pattern (update latest=false, insert latest=true). Code and tests already rely on the migration’s definition and filter by (account_id, slot, key) with is_latest_update=true. This edit removes is_latest_update from the PK in schema.rs to match the migration and the implemented logic.