### PR TITLE
chore: Add tx, block, and batch metrics

### DIFF
--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -277,6 +277,7 @@ impl BatchJob {
 
     #[instrument(target = COMPONENT, name = "batch_builder.commit_batch", skip_all)]
     async fn commit_batch(&self, batch: ProvenBatch) {
+        // Log the batch details.
         let transaction_ids = batch
             .transactions()
             .as_slice()

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -327,7 +327,7 @@ impl TelemetryInjectorExt for SelectedBatch {
         Span::current().set_attribute("transactions.count", self.transactions.len());
         Span::current().set_attribute(
             "transactions.ids",
-            self.transactions()
+            self.transactions
                 .as_slice()
                 .iter()
                 .map(|tx_header| tx_header.id())

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -230,6 +230,21 @@ impl BlockBuilder {
             .await
             .map_err(BuildBlockError::StoreApplyBlockFailed)?;
 
+        // Log the block details.
+        let tx_ids = built_block
+            .transactions()
+            .as_slice()
+            .iter()
+            .map(|tx_header| tx_header.id())
+            .collect::<Vec<_>>();
+        tracing::info!(
+            target: COMPONENT,
+            block_num = %built_block.header().block_num(),
+            transaction_count = tx_ids.len(),
+            transaction_ids = ?tx_ids,
+            "Committing batch"
+        );
+
         mempool.lock().await.commit_block(built_block.header().clone());
 
         Ok(())

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -8,6 +8,7 @@ use miden_objects::MIN_PROOF_SECURITY_LEVEL;
 use miden_objects::batch::ProvenBatch;
 use miden_objects::block::{BlockInputs, BlockNumber, ProposedBlock, ProvenBlock};
 use miden_objects::note::NoteHeader;
+use miden_objects::transaction::TransactionHeader;
 use miden_remote_prover_client::remote_prover::block_prover::RemoteBlockProver;
 use rand::Rng;
 use tokio::time::Duration;
@@ -279,14 +280,18 @@ impl TelemetryInjectorExt for SelectedBlock {
         span.set_attribute("block.number", self.block_number);
         span.set_attribute("block.batches.count", self.batches.len() as u32);
         // Accumulate all telemetry based on batches.
-        let (tx_count, tx_ids) =
-            self.batches.iter().fold((0, Vec::new()), |(acc, mut ids), batch| {
-                let tx_count = acc + batch.transactions().as_slice().len();
-                ids.extend(batch.transactions().as_slice().iter().map(|tx_header| tx_header.id()));
-                (tx_count, ids)
-            });
-        span.set_attribute("block.transactions.count", tx_count);
+        let (batch_ids, tx_ids, tx_count) = self.batches.iter().fold(
+            (Vec::new(), Vec::new(), 0),
+            |(mut batch_ids, mut tx_ids, tx_count), batch| {
+                let tx_count = tx_count + batch.transactions().as_slice().len();
+                tx_ids.extend(batch.transactions().as_slice().iter().map(TransactionHeader::id));
+                batch_ids.push(batch.id());
+                (batch_ids, tx_ids, tx_count)
+            },
+        );
+        span.set_attribute("block.batch.ids", batch_ids);
         span.set_attribute("block.transactions.ids", tx_ids);
+        span.set_attribute("block.transactions.count", tx_count);
     }
 }
 

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -278,6 +278,7 @@ impl TelemetryInjectorExt for SelectedBlock {
         let span = Span::current();
         span.set_attribute("block.number", self.block_number);
         span.set_attribute("block.batches.count", self.batches.len() as u32);
+        // Accumulate all telemetry based on batches.
         let (tx_count, tx_ids) =
             self.batches.iter().fold((0, Vec::new()), |(acc, mut ids), batch| {
                 let tx_count = acc + batch.transactions().as_slice().len();

--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -74,6 +74,13 @@ impl BlockStore {
         }
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "store.block_store.save_block",
+        skip(self, data),
+        err,
+        fields(block_size = data.len())
+    )]
     pub async fn save_block(
         &self,
         block_num: BlockNumber,
@@ -83,13 +90,6 @@ impl BlockStore {
         if !epoch_path.exists() {
             tokio::fs::create_dir_all(epoch_path).await?;
         }
-
-        tracing::info!(
-            target: COMPONENT,
-            block_num = %block_num,
-            block_size_kb = data.len() / 1024,
-            "Block saved to disk"
-        );
 
         tokio::fs::write(block_path, data).await
     }
@@ -103,13 +103,6 @@ impl BlockStore {
         if !epoch_path.exists() {
             std::fs::create_dir_all(epoch_path)?;
         }
-
-        tracing::info!(
-            target: COMPONENT,
-            block_num = %block_num,
-            block_size_kb = data.len() / 1024,
-            "Block saved to disk (blocking)"
-        );
 
         std::fs::write(block_path, data)
     }

--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -84,6 +84,13 @@ impl BlockStore {
             tokio::fs::create_dir_all(epoch_path).await?;
         }
 
+        tracing::info!(
+            target: COMPONENT,
+            block_num = %block_num,
+            block_size_kb = data.len() / 1024,
+            "Block saved to disk"
+        );
+
         tokio::fs::write(block_path, data).await
     }
 
@@ -96,6 +103,14 @@ impl BlockStore {
         if !epoch_path.exists() {
             std::fs::create_dir_all(epoch_path)?;
         }
+
+        let block_size = data.len();
+        tracing::info!(
+            target: COMPONENT,
+            block_num = %block_num,
+            block_size_kb = data.len() / 1024,
+            "Block saved to disk (blocking)"
+        );
 
         std::fs::write(block_path, data)
     }

--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -104,7 +104,6 @@ impl BlockStore {
             std::fs::create_dir_all(epoch_path)?;
         }
 
-        let block_size = data.len();
         tracing::info!(
             target: COMPONENT,
             block_num = %block_num,

--- a/crates/utils/src/tracing/span_ext.rs
+++ b/crates/utils/src/tracing/span_ext.rs
@@ -18,10 +18,7 @@ pub trait ToValue {
 
 impl<T: ToValue> ToValue for Vec<T> {
     fn to_value(&self) -> Value {
-        let string_values = self
-            .iter()
-            .map(|v| v.to_value().to_string().into())
-            .collect::<Vec<StringValue>>();
+        let string_values = self.iter().map(|v| v.to_value().into()).collect::<Vec<StringValue>>();
         Value::Array(string_values.into())
     }
 }

--- a/crates/utils/src/tracing/span_ext.rs
+++ b/crates/utils/src/tracing/span_ext.rs
@@ -5,14 +5,25 @@ use miden_objects::Word;
 use miden_objects::account::AccountId;
 use miden_objects::batch::BatchId;
 use miden_objects::block::BlockNumber;
+use miden_objects::transaction::TransactionId;
 use opentelemetry::trace::Status;
-use opentelemetry::{Key, Value};
+use opentelemetry::{Key, StringValue, Value};
 
 use crate::ErrorReport;
 
 /// Utility functions for converting types into [`opentelemetry::Value`].
 pub trait ToValue {
     fn to_value(&self) -> Value;
+}
+
+impl<T: ToValue> ToValue for Vec<T> {
+    fn to_value(&self) -> Value {
+        let string_values = self
+            .iter()
+            .map(|v| v.to_value().to_string().into())
+            .collect::<Vec<StringValue>>();
+        Value::Array(string_values.into())
+    }
 }
 
 impl ToValue for Duration {
@@ -40,6 +51,12 @@ impl ToValue for BlockNumber {
 }
 
 impl ToValue for BatchId {
+    fn to_value(&self) -> Value {
+        self.to_hex().into()
+    }
+}
+
+impl ToValue for TransactionId {
     fn to_value(&self) -> Value {
         self.to_hex().into()
     }


### PR DESCRIPTION
## Context

There are additional transaction, batch, and block metrics we could be capturing / observing.

Closes #1118.

## Changes
- Add transaction ids to batch attributes
- Add batch ids and transaction ids to block attributes
- Instrument save_block() with block number and size
