### PR TITLE
chore: bump miden-base commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "miden-block-prover"
 version = "0.12.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c5a7457c9fdf042e541db5bf5b33c1cb75ea4217"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#67842dc5356cf2c8cfcc158d0f7579b57a6e7985"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.12.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c5a7457c9fdf042e541db5bf5b33c1cb75ea4217"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#67842dc5356cf2c8cfcc158d0f7579b57a6e7985"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.12.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c5a7457c9fdf042e541db5bf5b33c1cb75ea4217"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#67842dc5356cf2c8cfcc158d0f7579b57a6e7985"
 dependencies = [
  "bech32",
  "getrandom 0.3.3",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "miden-testing"
 version = "0.12.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c5a7457c9fdf042e541db5bf5b33c1cb75ea4217"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#67842dc5356cf2c8cfcc158d0f7579b57a6e7985"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.12.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c5a7457c9fdf042e541db5bf5b33c1cb75ea4217"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#67842dc5356cf2c8cfcc158d0f7579b57a6e7985"
 dependencies = [
  "miden-lib",
  "miden-objects",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-batch-prover"
 version = "0.12.0"
-source = "git+https://github.com/0xMiden/miden-base?branch=next#c5a7457c9fdf042e541db5bf5b33c1cb75ea4217"
+source = "git+https://github.com/0xMiden/miden-base?branch=next#67842dc5356cf2c8cfcc158d0f7579b57a6e7985"
 dependencies = [
  "miden-objects",
  "miden-tx",


### PR DESCRIPTION
This PR updates the `miden-base` commit to `67842dc5356cf2c8cfcc158d0f7579b57a6e7985` to match the one currently used by miden-client.