### PR TITLE
chore: Display uri directly in span field

### DIFF
--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -8,17 +8,8 @@ use crate::tracing::OpenTelemetrySpanExt;
 /// Additionally also pulls in remote tracing context which allows the server trace to be connected
 /// to the client's origin trace.
 pub fn grpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
-    // A gRPC request's path ends with `../<service>/<method>`.
-    let mut path_segments = request.uri().path().rsplit('/');
-    let method = path_segments.next().unwrap_or_default();
-    let service = path_segments.next().unwrap_or_default();
-
-    // Create a span with a generic name - the actual span name will be set via otel.name
-    let span = tracing::info_span!("grpc_request", rpc.service = service, rpc.method = method);
-
-    // Set the dynamic span name that OpenTelemetry will use
-    // This allows us to have the proper <service>/<method> format without hardcoding
-    span.record("otel.name", format!("{service}/{method}"));
+    // Create a span with a generic, static name.
+    let span = tracing::info_span!("rpc", rpc.uri = %request.uri());
 
     // Pull the open-telemetry parent context using the HTTP extractor
     let otel_ctx = opentelemetry::global::get_text_map_propagator(|propagator| {


### PR DESCRIPTION
Debugging tracing in Honeycomb. The current approach doesn't work so this will simplify it to a (hopefully) working state.