### PR TITLE
feat(mempool): add tests

### DIFF
--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -66,8 +66,7 @@ mod nodes;
 mod state;
 mod subscription;
 
-// FIXME(Mirko): Re-enable these once mempool refactor is completed.
-#[cfg(all(false, test))]
+#[cfg(test)]
 mod tests;
 
 #[derive(Clone)]

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -520,10 +520,7 @@ impl Mempool {
                         "Reverted batch as part of block rollback"
                     );
                 },
-                NodeId::Transaction(_) => {},
-                NodeId::Block(block_number) => panic!(
-                    "Found block {block_number} descendent while reverting a block which shouldn't be possible since only one block is in progress"
-                ),
+                NodeId::Transaction(_) | NodeId::Block(_) => {},
             }
 
             for tx in node.transactions() {
@@ -600,7 +597,7 @@ impl Mempool {
                     },
                     NodeId::Transaction(_) => {},
                     NodeId::Block(block_number) => panic!(
-                        "Found block {block_number} descendent while reverting a block which shouldn't be possible since only one block is in progress"
+                        "Found block {block_number} descendent while reverting expired nodes which shouldn't be possible since only one block is in progress"
                     ),
                 }
 

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -163,7 +163,7 @@ fn block_commit_reverts_expired_txns() {
     uut.add_transaction(tx_to_revert).unwrap();
 
     // Commit the pending block which should revert the above tx.
-    let arb_header = BlockHeader::mock(0, None, None, &[], Word::empty());
+    let arb_header = BlockHeader::mock(block, None, None, &[], Word::empty());
     uut.commit_block(arb_header.clone());
     reference.commit_block(arb_header);
 
@@ -174,10 +174,10 @@ fn block_commit_reverts_expired_txns() {
 fn empty_block_commitment() {
     let mut uut = Mempool::for_tests();
 
-    let arb_header = BlockHeader::mock(0, None, None, &[], Word::empty());
     for _ in 0..3 {
-        let (_block, _) = uut.select_block();
-        uut.commit_block(arb_header.clone());
+        let (number, _) = uut.select_block();
+        let arb_header = BlockHeader::mock(number, None, None, &[], Word::empty());
+        uut.commit_block(arb_header);
     }
 }
 


### PR DESCRIPTION
This PR re-enables previous mempool tests, and adds a bunch of additional state related checks.

This adds confidence to the refactor, however more coverage with more complex batches and transaction graphs would be a good. Its somewhat difficult to create these though, and the better idea is letting it run in production for a bit with integration tests etc.

I think in the future it would have been a good idea to run this as a shadow network i.e. replay all blocks from the current testnet through it, in order.